### PR TITLE
Migrate existing components to Composition API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@mdi/font": "^6.5.95",
         "@types/lodash.clonedeep": "^4.5.6",
+        "@vue/composition-api": "^1.4.7",
         "ajv": "^8.10.0",
         "bignumber.js": "^9.0.2",
         "camel-case": "^4.1.2",
@@ -4161,6 +4162,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "node_modules/@vue/composition-api": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.4.7.tgz",
+      "integrity": "sha512-IaYlkcVTDzdVNVJNhpi3k0f5jWoLg4GJduO1pxJzItKCfGtaHAc3mxvxYc6bbsPzZ1DkW2MYJYmiiAfaYbmhIg==",
+      "peerDependencies": {
+        "vue": ">= 2.5 < 3"
+      }
     },
     "node_modules/@vue/eslint-config-typescript": {
       "version": "10.0.0",
@@ -23595,6 +23604,12 @@
           "dev": true
         }
       }
+    },
+    "@vue/composition-api": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.4.7.tgz",
+      "integrity": "sha512-IaYlkcVTDzdVNVJNhpi3k0f5jWoLg4GJduO1pxJzItKCfGtaHAc3mxvxYc6bbsPzZ1DkW2MYJYmiiAfaYbmhIg==",
+      "requires": {}
     },
     "@vue/eslint-config-typescript": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@mdi/font": "^6.5.95",
     "@types/lodash.clonedeep": "^4.5.6",
+    "@vue/composition-api": "^1.4.7",
     "ajv": "^8.10.0",
     "bignumber.js": "^9.0.2",
     "camel-case": "^4.1.2",

--- a/src/components/FontPreloader.vue
+++ b/src/components/FontPreloader.vue
@@ -18,19 +18,22 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 
-export default Vue.extend({
-  name: 'FontPreloader',
-  computed: {
-    fontFamilies () {
+export default defineComponent({
+  setup () {
+    const fontFamilies = computed(() => {
       return [
         'IPAGothic',
         'IPAPGothic',
         'IPAMincho',
         'IPAPMincho'
       ];
-    }
+    });
+
+    return {
+      fontFamilies
+    };
   }
 });
 </script>

--- a/src/components/LayerItemDragger.vue
+++ b/src/components/LayerItemDragger.vue
@@ -60,6 +60,40 @@ export default defineComponent({
     });
     const draggerState = computed(() => operator.state.itemDragger);
 
+    const cancel = () => {
+      operator.actions.finishItemDrag();
+    };
+    const moveItemTo = (bounds: BoundingPoints) => {
+      if (!draggerState.value.itemUid || !itemType.value) throw new UnexpectedStateError();
+
+      const payload = { uid: draggerState.value.itemUid, bounds };
+
+      switch (itemType.value) {
+        case 'rect': report.actions.moveRectItemTo(payload); break;
+        case 'ellipse': report.actions.moveEllipseItemTo(payload); break;
+        case 'line': report.actions.moveLineItemTo(payload); break;
+        case 'image-block': report.actions.moveImageBlockItemTo(payload); break;
+        case 'image': report.actions.moveImageItemTo(payload); break;
+        case 'text': report.actions.moveTextItemTo(payload); break;
+        case 'text-block': report.actions.moveTextBlockItemTo(payload); break;
+        case 'stack-view': report.actions.moveStackViewItemTo(payload); break;
+        default:
+          throw new Error('Not Implemented');
+      }
+    };
+    const convertToReportCoords = (boundingPoints: BoundingPoints): BoundingPoints => {
+      const localTranslation = draggerState.value.translation;
+      if (!localTranslation) throw new UnexpectedStateError();
+
+      return new BoundsTransformer(boundingPoints).expand(localTranslation).toBPoints();
+    };
+    const convertToLocalCoords = (boundingPoints: BoundingPoints): BoundingPoints => {
+      const localTranslation = draggerState.value.translation;
+      if (!localTranslation) throw new UnexpectedStateError();
+
+      return new BoundsTransformer(boundingPoints).relativeFrom(localTranslation).toBPoints();
+    };
+
     const start = (e: MouseEvent) => {
       const point = transformSvgPoint.value(e);
 
@@ -101,39 +135,6 @@ export default defineComponent({
       moveItemTo(convertToLocalCoords(outlineBounds.value));
 
       operator.actions.finishItemDrag();
-    };
-    const cancel = () => {
-      operator.actions.finishItemDrag();
-    };
-    const moveItemTo = (bounds: BoundingPoints) => {
-      if (!draggerState.value.itemUid || !itemType.value) throw new UnexpectedStateError();
-
-      const payload = { uid: draggerState.value.itemUid, bounds };
-
-      switch (itemType.value) {
-        case 'rect': report.actions.moveRectItemTo(payload); break;
-        case 'ellipse': report.actions.moveEllipseItemTo(payload); break;
-        case 'line': report.actions.moveLineItemTo(payload); break;
-        case 'image-block': report.actions.moveImageBlockItemTo(payload); break;
-        case 'image': report.actions.moveImageItemTo(payload); break;
-        case 'text': report.actions.moveTextItemTo(payload); break;
-        case 'text-block': report.actions.moveTextBlockItemTo(payload); break;
-        case 'stack-view': report.actions.moveStackViewItemTo(payload); break;
-        default:
-          throw new Error('Not Implemented');
-      }
-    };
-    const convertToReportCoords = (boundingPoints: BoundingPoints): BoundingPoints => {
-      const localTranslation = draggerState.value.translation;
-      if (!localTranslation) throw new UnexpectedStateError();
-
-      return new BoundsTransformer(boundingPoints).expand(localTranslation).toBPoints();
-    };
-    const convertToLocalCoords = (boundingPoints: BoundingPoints): BoundingPoints => {
-      const localTranslation = draggerState.value.translation;
-      if (!localTranslation) throw new UnexpectedStateError();
-
-      return new BoundsTransformer(boundingPoints).relativeFrom(localTranslation).toBPoints();
     };
 
     return {

--- a/src/components/LayerItemDrawer.vue
+++ b/src/components/LayerItemDrawer.vue
@@ -20,15 +20,11 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, ref, toRefs } from '@vue/composition-api';
 import { BoundsTransformer } from '../lib/bounds-transformer';
 import { operator, report, editor } from '../store';
 import ItemOutline from './items/ItemOutline.vue';
 import { BoundingPoints, Coords } from '@/types';
-
-type Data = {
-  outlineBounds: BoundingPoints | null;
-};
 
 class UnexpectedStateError extends Error {
   constructor () {
@@ -37,8 +33,7 @@ class UnexpectedStateError extends Error {
   }
 }
 
-export default Vue.extend({
-  name: 'LayerItemDrawer',
+export default defineComponent({
   components: {
     ItemOutline
   },
@@ -48,67 +43,65 @@ export default Vue.extend({
       required: true
     },
     transformSvgPoint: {
-      type: Function as PropType<(point: Coords) => Coords>,
+      type: (Function as unknown) as () => (point: Coords) => Coords,
       required: true
     }
   },
-  data (): Data {
-    return {
-      outlineBounds: null
-    };
-  },
-  computed: {
-    isStarted (): boolean {
-      return this.outlineBounds !== null;
-    },
-    drawerState: () => operator.state.itemDrawer
-  },
-  methods: {
-    start (e: MouseEvent) {
-      const point = this.transformSvgPoint(e);
+  setup (props) {
+    const { transformSvgPoint } = toRefs(props);
 
-      this.outlineBounds = {
+    const outlineBounds = ref<BoundingPoints | null>(null);
+
+    const isStarted = computed((): boolean => {
+      return outlineBounds.value !== null;
+    });
+    const drawerState = computed(() => operator.state.itemDrawer);
+
+    const start = (e: MouseEvent) => {
+      const point = transformSvgPoint.value(e);
+
+      outlineBounds.value = {
         x1: point.x,
         y1: point.y,
         x2: point.x,
         y2: point.y
       };
-    },
-    draw (e: MouseEvent) {
-      const point = this.transformSvgPoint(e);
+    };
+    const draw = (e: MouseEvent) => {
+      const point = transformSvgPoint.value(e);
 
-      if (!this.isStarted) this.start(e);
-      if (!this.outlineBounds) throw new UnexpectedStateError();
+      if (!isStarted.value) start(e);
+      if (!outlineBounds.value) throw new UnexpectedStateError();
 
-      this.outlineBounds.x2 = point.x;
-      this.outlineBounds.y2 = point.y;
-    },
-    finish () {
-      if (!this.isStarted || this.isOutlineEmpty()) {
-        this.cancel();
+      outlineBounds.value.x2 = point.x;
+      outlineBounds.value.y2 = point.y;
+    };
+    const finish = () => {
+      if (!isStarted.value || isOutlineEmpty()) {
+        cancel();
         return;
       }
 
-      if (!this.outlineBounds) throw new UnexpectedStateError();
+      if (!outlineBounds.value) throw new UnexpectedStateError();
 
-      this.drawNewItem(this.convertToLocalCoords(this.outlineBounds));
+      drawNewItem(convertToLocalCoords(outlineBounds.value));
 
       operator.actions.finishItemDraw();
       editor.actions.activateTool({ tool: 'select' });
-    },
-    cancel () {
+    };
+    const cancel = () => {
       operator.actions.finishItemDraw();
-    },
-    isOutlineEmpty () {
-      if (this.outlineBounds) {
-        const box = new BoundsTransformer(this.outlineBounds).toBBox();
+    };
+    const isOutlineEmpty = () => {
+      if (outlineBounds.value) {
+        const box = new BoundsTransformer(outlineBounds.value).toBBox();
         return box.width < 4 && box.height < 4;
       } else {
         return true;
       }
-    },
-    drawNewItem (bounds: BoundingPoints) {
-      const { itemType, targetType, targetUid } = this.drawerState;
+    };
+    const drawNewItem = (bounds: BoundingPoints) => {
+      const { itemType, targetType, targetUid } = drawerState.value;
 
       if (!itemType || !targetType || !targetUid) throw new UnexpectedStateError();
 
@@ -125,13 +118,21 @@ export default Vue.extend({
         default:
           throw new Error(`Invalid itemType: ${itemType}`);
       }
-    },
-    convertToLocalCoords (bPoints: BoundingPoints): BoundingPoints {
-      const localTranslation = this.drawerState.translation;
+    };
+    const convertToLocalCoords = (bPoints: BoundingPoints): BoundingPoints => {
+      const localTranslation = drawerState.value.translation;
       if (!localTranslation) throw new UnexpectedStateError();
 
       return new BoundsTransformer(bPoints).relativeFrom(localTranslation).toBPoints();
-    }
+    };
+
+    return {
+      outlineBounds,
+      isStarted,
+      drawerState,
+      draw,
+      finish
+    };
   }
 });
 </script>

--- a/src/components/LayerItemDrawer.vue
+++ b/src/components/LayerItemDrawer.vue
@@ -57,38 +57,6 @@ export default defineComponent({
     });
     const drawerState = computed(() => operator.state.itemDrawer);
 
-    const start = (e: MouseEvent) => {
-      const point = transformSvgPoint.value(e);
-
-      outlineBounds.value = {
-        x1: point.x,
-        y1: point.y,
-        x2: point.x,
-        y2: point.y
-      };
-    };
-    const draw = (e: MouseEvent) => {
-      const point = transformSvgPoint.value(e);
-
-      if (!isStarted.value) start(e);
-      if (!outlineBounds.value) throw new UnexpectedStateError();
-
-      outlineBounds.value.x2 = point.x;
-      outlineBounds.value.y2 = point.y;
-    };
-    const finish = () => {
-      if (!isStarted.value || isOutlineEmpty()) {
-        cancel();
-        return;
-      }
-
-      if (!outlineBounds.value) throw new UnexpectedStateError();
-
-      drawNewItem(convertToLocalCoords(outlineBounds.value));
-
-      operator.actions.finishItemDraw();
-      editor.actions.activateTool({ tool: 'select' });
-    };
     const cancel = () => {
       operator.actions.finishItemDraw();
     };
@@ -124,6 +92,39 @@ export default defineComponent({
       if (!localTranslation) throw new UnexpectedStateError();
 
       return new BoundsTransformer(bPoints).relativeFrom(localTranslation).toBPoints();
+    };
+
+    const start = (e: MouseEvent) => {
+      const point = transformSvgPoint.value(e);
+
+      outlineBounds.value = {
+        x1: point.x,
+        y1: point.y,
+        x2: point.x,
+        y2: point.y
+      };
+    };
+    const draw = (e: MouseEvent) => {
+      const point = transformSvgPoint.value(e);
+
+      if (!isStarted.value) start(e);
+      if (!outlineBounds.value) throw new UnexpectedStateError();
+
+      outlineBounds.value.x2 = point.x;
+      outlineBounds.value.y2 = point.y;
+    };
+    const finish = () => {
+      if (!isStarted.value || isOutlineEmpty()) {
+        cancel();
+        return;
+      }
+
+      if (!outlineBounds.value) throw new UnexpectedStateError();
+
+      drawNewItem(convertToLocalCoords(outlineBounds.value));
+
+      operator.actions.finishItemDraw();
+      editor.actions.activateTool({ tool: 'select' });
     };
 
     return {

--- a/src/components/PropertyPane.vue
+++ b/src/components/PropertyPane.vue
@@ -21,14 +21,13 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { report } from '../store';
 import ItemProperties from './property/ItemProperties.vue';
 import SectionProperties from './property/SectionProperties.vue';
 import StackViewRowProperties from './property/StackViewRowProperties.vue';
 
-export default Vue.extend({
-  name: 'PropertyPane',
+export default defineComponent({
   components: {
     ItemProperties,
     SectionProperties,
@@ -40,10 +39,16 @@ export default Vue.extend({
       required: true
     }
   },
-  computed: {
-    activeItem: () => report.getters.activeItem(),
-    activeStackViewRow: () => report.getters.activeStackViewRow(),
-    activeSection: () => report.getters.activeSection()
+  setup () {
+    const activeItem = computed(() => report.getters.activeItem());
+    const activeStackViewRow = computed(() => report.getters.activeStackViewRow());
+    const activeSection = computed(() => report.getters.activeSection());
+
+    return {
+      activeItem,
+      activeStackViewRow,
+      activeSection
+    };
   }
 });
 </script>

--- a/src/components/ReportCanvas.vue
+++ b/src/components/ReportCanvas.vue
@@ -51,21 +51,21 @@ export default defineComponent({
     CanvasSelector
   },
   setup () {
+    const sections = computed(() => report.getters.sections());
     const sectionWithPositions = computed((): SectionWithPosition[] => {
-      const sections: {
+      const result: {
         schema: Section;
         top: number;
       }[] = [];
 
       let top = 0;
       sections.value.forEach(section => {
-        sections.push({ schema: section, top });
+        result.push({ schema: section, top });
         top = calcPlus(top, section.height);
       });
 
-      return sections;
+      return result;
     });
-    const sections = computed(() => report.getters.sections());
     const contentSize = computed((): Size => report.getters.contentSize());
 
     const activateSection = (uid: SectionUid) => {

--- a/src/components/ReportCanvas.vue
+++ b/src/components/ReportCanvas.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { calcPlus } from '../lib/strict-calculator';
 import { report } from '../store';
 import SectionCanvas from './SectionCanvas.vue';
@@ -44,46 +44,52 @@ type SectionWithPosition = {
   top: number;
 };
 
-export default Vue.extend({
-  name: 'ReportCanvas',
+export default defineComponent({
   components: {
     SectionCanvas,
     SectionDivider,
     CanvasSelector
   },
-  computed: {
-    sectionWithPositions (): SectionWithPosition[] {
+  setup () {
+    const sectionWithPositions = computed((): SectionWithPosition[] => {
       const sections: {
         schema: Section;
         top: number;
       }[] = [];
 
       let top = 0;
-      this.sections.forEach(section => {
+      sections.value.forEach(section => {
         sections.push({ schema: section, top });
         top = calcPlus(top, section.height);
       });
 
       return sections;
-    },
-    sections: () => report.getters.sections(),
-    contentSize: (): Size => report.getters.contentSize()
-  },
-  methods: {
-    activateSection (uid: SectionUid) {
+    });
+    const sections = computed(() => report.getters.sections());
+    const contentSize = computed((): Size => report.getters.contentSize());
+
+    const activateSection = (uid: SectionUid) => {
       report.actions.activateEntity({ uid, type: 'section' });
-    },
-    selectorBounds ({ schema, top }: SectionWithPosition): BoundingBox {
+    };
+    const selectorBounds = ({ schema, top }: SectionWithPosition): BoundingBox => {
       return {
         x: 0,
         y: top,
-        width: this.contentSize.width,
+        width: contentSize.value.width,
         height: schema.height
       };
-    },
-    isLastSection (index: number): boolean {
-      return this.sections.length === index + 1;
-    }
+    };
+    const isLastSection = (index: number): boolean => {
+      return sections.value.length === index + 1;
+    };
+
+    return {
+      sectionWithPositions,
+      contentSize,
+      activateSection,
+      selectorBounds,
+      isLastSection
+    };
   }
 });
 </script>

--- a/src/components/ReportPane.vue
+++ b/src/components/ReportPane.vue
@@ -1,13 +1,13 @@
 <template>
   <div
-    ref="container"
+    ref="refContainer"
     class="th-report-pane"
   >
     <svg
-      ref="canvasSvg"
+      ref="refCanvasSvg"
       :viewBox="viewBox"
-      :width="width || '100%'"
-      :height="height || '100%'"
+      :width="canvasWidth || '100%'"
+      :height="canvasHeight || '100%'"
       :style="{ minWidth }"
       preserveAspectRatio="none"
       xmlns="http://www.w3.org/2000/svg"
@@ -15,7 +15,7 @@
       version="1.1"
     >
       <g
-        ref="canvas"
+        ref="refCanvas"
         :transform="reportTransform"
       >
         <ReportCanvas />
@@ -37,7 +37,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, nextTick, ref } from '@vue/composition-api';
+import { computed, defineComponent, nextTick, onBeforeMount, onMounted, ref } from '@vue/composition-api';
 import { calcDiv, calcMinus, calcMul } from '../lib/strict-calculator';
 import { Translation, Size, Coords } from '../types';
 import LayerItemDragger from './LayerItemDragger.vue';
@@ -53,22 +53,36 @@ export default defineComponent({
     LayerItemDrawer,
     LayerItemDragger
   },
-  created () {
-    report.actions.addInitialSections();
-  },
-  mounted () {
-    window.addEventListener('resize', recalculateContainerSize);
-    nextTick(() => recalculateContainerSize());
-  },
-  beforeDestroy () {
-    window.removeEventListener('resize', recalculateContainerSize);
-  },
   setup () {
+    const refContainer = ref(null);
+    const refCanvasSvg = ref(null);
+    const refCanvas = ref(null);
     const containerSize = ref<Size | null>(null);
 
+    const contentSize = computed((): Size => {
+      const { width, height } = report.getters.contentSize();
+      const zoomRate = editor.getters.zoomRate();
+      return {
+        width: calcMul(width, zoomRate),
+        height: calcMul(height, zoomRate)
+      };
+    });
+    const canvasWidth = computed((): number | null => {
+      if (!containerSize.value) return null;
+      return containerSize.value.width < contentSize.value.width + REPORT_MARGIN_PX * 2 ? contentSize.value.width + REPORT_MARGIN_PX * 2 : containerSize.value.width;
+    });
+    const canvasHeight = computed((): number | null => {
+      if (!containerSize.value) return null;
+      return (containerSize.value.height < contentSize.value.height + REPORT_MARGIN_PX * 2 ? contentSize.value.height + REPORT_MARGIN_PX * 2 : containerSize.value.height);
+    });
+    const minWidth = computed((): string => {
+      return canvasWidth.value !== null ? `${canvasWidth.value}px` : '100%';
+    });
+    const isItemDraggerActive = computed(() => operator.state.itemDragger.active);
+    const isItemDrawerActive = computed(() => operator.state.itemDrawer.active);
     const reportTranslation = computed((): Translation => {
-      if (width.value !== null && height.value !== null) {
-        const x = calcMinus(calcDiv(width.value, 2), calcDiv(contentSize.value.width, 2));
+      if (canvasWidth.value !== null && canvasHeight.value !== null) {
+        const x = calcMinus(calcDiv(canvasWidth.value, 2), calcDiv(contentSize.value.width, 2));
         return {
           x: x < REPORT_MARGIN_PX ? REPORT_MARGIN_PX : x,
           y: REPORT_MARGIN_PX
@@ -82,44 +96,23 @@ export default defineComponent({
       return `translate(${translation.x},${translation.y}) scale(${editor.getters.zoomRate()})`;
     });
     const viewBox = computed((): string | null => {
-      if (width.value !== null && height.value !== null) {
-        return [0, 0, width.value, height.value].join(' ');
+      if (canvasWidth.value !== null && canvasHeight.value !== null) {
+        return [0, 0, canvasWidth.value, canvasHeight.value].join(' ');
       } else {
         return null;
       }
     });
-    const minWidth = computed((): string => {
-      return width.value !== null ? `${width.value}px` : '100%';
-    });
-    const width = computed((): number | null => {
-      if (!containerSize.value) return null;
-      return containerSize.value.width < contentSize.value.width + REPORT_MARGIN_PX * 2 ? contentSize.value.width + REPORT_MARGIN_PX * 2 : containerSize.value.width;
-    });
-    const height = computed((): number | null => {
-      if (!containerSize.value) return null;
-      return (containerSize.value.height < contentSize.value.height + REPORT_MARGIN_PX * 2 ? contentSize.value.height + REPORT_MARGIN_PX * 2 : containerSize.value.height);
-    });
-    const isItemDraggerActive = computed(() => operator.state.itemDragger.active);
-    const isItemDrawerActive = computed(() => operator.state.itemDrawer.active);
-    const contentSize = computed((): Size => {
-      const { width, height } = report.getters.contentSize();
-      const zoomRate = editor.getters.zoomRate();
-      return {
-        width: calcMul(width, zoomRate),
-        height: calcMul(height, zoomRate)
-      };
-    });
 
     const recalculateContainerSize = () => {
-      const containerClientRect = (this.$refs.container as HTMLElement).getBoundingClientRect();
+      const containerClientRect = (refContainer.value! as HTMLElement).getBoundingClientRect();
       containerSize.value = {
         width: containerClientRect.width,
         height: containerClientRect.height
       };
     };
     const transformSvgPoint = (point: Coords): Coords => {
-      const canvasSvg = this.$refs.canvasSvg as SVGSVGElement;
-      const canvas = this.$refs.canvas as SVGGElement;
+      const canvasSvg = refCanvasSvg.value! as SVGSVGElement;
+      const canvas = refCanvas.value! as SVGGElement;
       const canvasCTM = canvas.getScreenCTM();
 
       if (!canvasCTM) throw new Error('Failed to transform point');
@@ -136,15 +129,30 @@ export default defineComponent({
       };
     };
 
+    // created
+    report.actions.addInitialSections();
+
+    onMounted(() => {
+      window.addEventListener('resize', recalculateContainerSize);
+      nextTick(() => recalculateContainerSize());
+    });
+
+    onBeforeMount(() => {
+      window.removeEventListener('resize', recalculateContainerSize);
+    });
+
     return {
       reportTransform,
       viewBox,
       minWidth,
-      width,
-      height,
+      canvasWidth,
+      canvasHeight,
       isItemDraggerActive,
       isItemDrawerActive,
-      transformSvgPoint
+      transformSvgPoint,
+      refContainer,
+      refCanvasSvg,
+      refCanvas
     };
   }
 });

--- a/src/components/SectionCanvas.vue
+++ b/src/components/SectionCanvas.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, toRefs } from '@vue/composition-api';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { report, operator, editor } from '../store';
 import SectionCanvasHighlighter from './SectionCanvasHighlighter.vue';
 import CanvasDrawer from './base/CanvasDrawer.vue';
@@ -71,18 +71,16 @@ export default defineComponent({
   setup (props) {
     const { section, top } = toRefs(props);
 
-    const pointerDown = ref(false);
-
     const paperSize = computed(() => report.getters.paperSize());
     const isDrawMode = computed(() => editor.getters.isDrawMode());
     const width = computed((): number => {
       return paperSize.value.width;
     });
-    const transform = computed((): string => {
-      return `translate(${Object.values(translation.value).join(',')})`;
-    });
     const translation = computed((): Coords => {
       return { x: 0, y: top.value };
+    });
+    const transform = computed((): string => {
+      return `translate(${Object.values(translation.value).join(',')})`;
     });
     const isActive = computed((): boolean => {
       return report.getters.isActiveSection(section.value.uid);

--- a/src/components/SectionCanvasHighlighter.vue
+++ b/src/components/SectionCanvasHighlighter.vue
@@ -10,22 +10,25 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { inverseScale } from '../lib/inverse-scale';
 import { editor } from '../store';
 
-export default Vue.extend({
-  name: 'SectionCanvasHighlighter',
+export default defineComponent({
   props: {
     height: {
       type: Number,
       required: true
     }
   },
-  computed: {
-    strokeWidth (): number {
+  setup () {
+    const strokeWidth = computed((): number => {
       return inverseScale(1, editor.getters.zoomRate());
-    }
+    });
+
+    return {
+      strokeWidth
+    };
   }
 });
 </script>

--- a/src/components/SectionDivider.vue
+++ b/src/components/SectionDivider.vue
@@ -10,12 +10,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { inverseScale } from '../lib/inverse-scale';
 import { editor } from '../store';
 
-export default Vue.extend({
-  name: 'SectionDivider',
+export default defineComponent({
   props: {
     top: {
       type: Number,
@@ -26,10 +25,14 @@ export default Vue.extend({
       required: true
     }
   },
-  computed: {
-    strokeWidth (): number {
+  setup () {
+    const strokeWidth = computed((): number => {
       return inverseScale(1, editor.getters.zoomRate());
-    }
+    });
+
+    return {
+      strokeWidth
+    };
   }
 });
 </script>

--- a/src/components/ToolbarPane.vue
+++ b/src/components/ToolbarPane.vue
@@ -5,11 +5,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import ToolSelect from './toolbar/ToolSelect.vue';
 
-export default Vue.extend({
-  name: 'ToolbarPane',
+export default defineComponent({
   components: {
     ToolSelect
   }

--- a/src/components/TreeViewPane.vue
+++ b/src/components/TreeViewPane.vue
@@ -18,13 +18,12 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { report } from '../store';
 import { SectionUid } from '../types';
 import SectionNode from './tree-view/SectionNode.vue';
 
-export default Vue.extend({
-  name: 'TreeViewPane',
+export default defineComponent({
   components: {
     SectionNode
   },
@@ -34,14 +33,19 @@ export default Vue.extend({
       required: true
     }
   },
-  computed: {
-    sections: () => report.getters.sections(),
-    activeSectionUid: () => report.getters.activeSection()?.uid
-  },
-  methods: {
-    activateSection (uid: SectionUid) {
+  setup () {
+    const sections = computed(() => report.getters.sections());
+    const activeSectionUid = computed(() => report.getters.activeSection()?.uid);
+
+    const activateSection = (uid: SectionUid) => {
       report.actions.activateEntity({ type: 'section', uid });
-    }
+    };
+
+    return {
+      sections,
+      activeSectionUid,
+      activateSection
+    };
   }
 });
 </script>

--- a/src/components/base/CanvasDrawer.vue
+++ b/src/components/base/CanvasDrawer.vue
@@ -12,10 +12,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, ref } from '@vue/composition-api';
 
-export default Vue.extend({
-  name: 'CanvasDrawer',
+export default defineComponent({
   props: {
     width: {
       type: Number,
@@ -26,27 +25,30 @@ export default Vue.extend({
       required: true
     }
   },
-  data () {
-    return {
-      pointerDown: false
+  setup (_, { emit }) {
+    const pointerDown = ref(false);
+
+    const emitStartDraw = () => {
+      emit('startDraw');
     };
-  },
-  methods: {
-    emitStartDraw () {
-      this.$emit('startDraw');
-    },
-    onPointerDown () {
-      this.pointerDown = true;
-    },
-    onPointerMove () {
-      if (this.pointerDown) {
-        this.emitStartDraw();
-        this.pointerDown = false;
+    const onPointerDown = () => {
+      pointerDown.value = true;
+    };
+    const onPointerMove = () => {
+      if (pointerDown.value) {
+        emitStartDraw();
+        pointerDown.value = false;
       }
-    },
-    onPointerUp () {
-      this.pointerDown = false;
-    }
+    };
+    const onPointerUp = () => {
+      pointerDown.value = false;
+    };
+
+    return {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp
+    };
   }
 });
 </script>

--- a/src/components/base/CanvasSelector.vue
+++ b/src/components/base/CanvasSelector.vue
@@ -10,21 +10,24 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import { BoundingBox } from '@/types';
 
-export default Vue.extend({
-  name: 'CanvasSelector',
+export default defineComponent({
   props: {
     bounds: {
-      type: Object as PropType<BoundingBox>,
+      type: Object as () => BoundingBox,
       required: true
     }
   },
-  methods: {
-    emitSelect () {
-      this.$emit('select');
-    }
+  setup (_, { emit }) {
+    const emitSelect = () => {
+      emit('select');
+    };
+
+    return {
+      emitSelect
+    };
   }
 });
 </script>

--- a/src/components/icons/ItemIcon.vue
+++ b/src/components/icons/ItemIcon.vue
@@ -3,20 +3,21 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { ItemType } from '../../types';
 
-export default Vue.extend({
-  name: 'ItemIcon',
+export default defineComponent({
   props: {
     type: {
-      type: String as PropType<ItemType>,
+      type: String as () => ItemType,
       required: true
     }
   },
-  computed: {
-    iconClass () {
-      switch (this.type) {
+  setup (props) {
+    const { type } = toRefs(props);
+
+    const iconClass = computed(() => {
+      switch (type.value) {
         case 'rect': return 'mdi mdi-rectangle-outline';
         case 'ellipse': return 'mdi mdi-ellipse-outline';
         case 'line': return 'mdi mdi-vector-line';
@@ -27,7 +28,11 @@ export default Vue.extend({
         case 'stack-view': return 'mdi mdi-table-column';
         default: throw new Error('Invalid item type');
       }
-    }
+    });
+
+    return {
+      iconClass
+    };
   }
 });
 </script>

--- a/src/components/icons/SectionIcon.vue
+++ b/src/components/icons/SectionIcon.vue
@@ -3,26 +3,31 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { SectionType } from '../../types';
 
-export default Vue.extend({
-  name: 'SectionIcon',
+export default defineComponent({
   props: {
     type: {
-      type: String as PropType<SectionType>,
+      type: String as () => SectionType,
       required: true
     }
   },
-  computed: {
-    iconClass () {
-      switch (this.type) {
+  setup (props) {
+    const { type } = toRefs(props);
+
+    const iconClass = computed(() => {
+      switch (type.value) {
         case 'header': return 'mdi mdi-page-layout-header';
         case 'detail': return 'mdi mdi-page-layout-body';
         case 'footer': return 'mdi mdi-page-layout-footer';
         default: throw new Error('Invalid section type');
       }
-    }
+    });
+
+    return {
+      iconClass
+    };
   }
 });
 </script>

--- a/src/components/items/BoxItemHighlighter.vue
+++ b/src/components/items/BoxItemHighlighter.vue
@@ -12,17 +12,16 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { inverseScale } from '../../lib/inverse-scale';
 import { calcMinus, calcPlus, calcMul, calcDiv } from '../../lib/strict-calculator';
 import { editor } from '../../store';
 import { BoundingBox } from '@/types';
 
-export default Vue.extend({
-  name: 'BoxItemHighlighter',
+export default defineComponent({
   props: {
     itemBounds: {
-      type: Object as PropType<BoundingBox>,
+      type: Object as () => BoundingBox,
       required: true
     },
     itemStrokeWidth: {
@@ -34,28 +33,39 @@ export default Vue.extend({
       default: 0
     }
   },
-  computed: {
-    x (): number {
-      return calcMinus(this.itemBounds.x, this.extraSize);
-    },
-    y (): number {
-      return calcMinus(this.itemBounds.y, this.extraSize);
-    },
-    width (): number {
-      return calcPlus(this.itemBounds.width, calcMul(this.extraSize, 2));
-    },
-    height (): number {
-      return calcPlus(this.itemBounds.height, calcMul(this.extraSize, 2));
-    },
-    strokeWidth (): number {
+  setup (props) {
+    const { itemBounds, itemStrokeWidth, itemBorderRadius } = toRefs(props);
+
+    const x = computed((): number => {
+      return calcMinus(itemBounds.value.x, extraSize.value);
+    });
+    const y = computed((): number => {
+      return calcMinus(itemBounds.value.y, extraSize.value);
+    });
+    const width = computed((): number => {
+      return calcPlus(itemBounds.value.width, calcMul(extraSize.value, 2));
+    });
+    const height = computed((): number => {
+      return calcPlus(itemBounds.value.height, calcMul(extraSize.value, 2));
+    });
+    const strokeWidth = computed((): number => {
       return inverseScale(3, editor.getters.zoomRate());
-    },
-    extraSize (): number {
-      return calcPlus(calcDiv(this.itemStrokeWidth, 2), calcDiv(this.strokeWidth, 2));
-    },
-    radius (): number {
-      return this.itemBorderRadius !== 0 ? this.itemBorderRadius + 1 : 0;
-    }
+    });
+    const extraSize = computed((): number => {
+      return calcPlus(calcDiv(itemStrokeWidth.value, 2), calcDiv(strokeWidth.value, 2));
+    });
+    const radius = computed((): number => {
+      return itemBorderRadius.value !== 0 ? itemBorderRadius.value + 1 : 0;
+    });
+
+    return {
+      x,
+      y,
+      width,
+      height,
+      strokeWidth,
+      radius
+    };
   }
 });
 </script>

--- a/src/components/items/BoxItemHighlighter.vue
+++ b/src/components/items/BoxItemHighlighter.vue
@@ -36,6 +36,12 @@ export default defineComponent({
   setup (props) {
     const { itemBounds, itemStrokeWidth, itemBorderRadius } = toRefs(props);
 
+    const strokeWidth = computed((): number => {
+      return inverseScale(3, editor.getters.zoomRate());
+    });
+    const extraSize = computed((): number => {
+      return calcPlus(calcDiv(itemStrokeWidth.value, 2), calcDiv(strokeWidth.value, 2));
+    });
     const x = computed((): number => {
       return calcMinus(itemBounds.value.x, extraSize.value);
     });
@@ -47,12 +53,6 @@ export default defineComponent({
     });
     const height = computed((): number => {
       return calcPlus(itemBounds.value.height, calcMul(extraSize.value, 2));
-    });
-    const strokeWidth = computed((): number => {
-      return inverseScale(3, editor.getters.zoomRate());
-    });
-    const extraSize = computed((): number => {
-      return calcPlus(calcDiv(itemStrokeWidth.value, 2), calcDiv(strokeWidth.value, 2));
     });
     const radius = computed((): number => {
       return itemBorderRadius.value !== 0 ? itemBorderRadius.value + 1 : 0;

--- a/src/components/items/BoxItemOutline.vue
+++ b/src/components/items/BoxItemOutline.vue
@@ -10,23 +10,26 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { inverseScale } from '../../lib/inverse-scale';
 import { editor } from '../../store';
 import { Bounds } from '@/types';
 
-export default Vue.extend({
-  name: 'ItemBoundingBoxOutline',
+export default defineComponent({
   props: {
     bounds: {
-      type: Object as PropType<Bounds>,
+      type: Object as () => Bounds,
       required: true
     }
   },
-  computed: {
-    strokeWidth (): number {
+  setup () {
+    const strokeWidth = computed((): number => {
       return inverseScale(1, editor.getters.zoomRate());
-    }
+    });
+
+    return {
+      strokeWidth
+    };
   }
 });
 </script>

--- a/src/components/items/EllipseItem.vue
+++ b/src/components/items/EllipseItem.vue
@@ -13,15 +13,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { report } from '../../store';
 import EllipseItemBody from './EllipseItemBody.vue';
 import EllipseItemHighlighter from './EllipseItemHighlighter.vue';
 import ItemEntity from './ItemEntity.vue';
 import { EllipseItem } from '@/types';
 
-export default Vue.extend({
-  name: 'EllipseItem',
+export default defineComponent({
   components: {
     ItemEntity,
     EllipseItemBody,
@@ -29,22 +28,29 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<EllipseItem>,
+      type: Object as () => EllipseItem,
       required: true
     }
   },
-  computed: {
-    isActive (): boolean {
-      return report.getters.isActiveItem(this.item.uid);
-    }
-  },
-  methods: {
-    dragStart () {
-      this.$emit('itemDragStart', this.item);
-    },
-    activate () {
-      report.actions.activateEntity({ uid: this.item.uid, type: 'item' });
-    }
+  setup (props, { emit }) {
+    const { item } = toRefs(props);
+
+    const isActive = computed((): boolean => {
+      return report.getters.isActiveItem(item.value.uid);
+    });
+
+    const dragStart = () => {
+      emit('itemDragStart', item.value);
+    };
+    const activate = () => {
+      report.actions.activateEntity({ uid: item.value.uid, type: 'item' });
+    };
+
+    return {
+      isActive,
+      dragStart,
+      activate
+    };
   }
 });
 </script>

--- a/src/components/items/EllipseItemBody.vue
+++ b/src/components/items/EllipseItemBody.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { EllipseItem } from '@/types';
 
 type Style = {
@@ -25,23 +25,28 @@ const STROKE_DASHARRAY_MAP = {
   dotted: '1,1'
 } as const;
 
-export default Vue.extend({
-  name: 'EllipseItemBody',
+export default defineComponent({
   props: {
     item: {
-      type: Object as PropType<EllipseItem>,
+      type: Object as () => EllipseItem,
       required: true
     }
   },
-  computed: {
-    style (): Style {
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const style = computed((): Style => {
       return {
-        strokeWidth: this.item.style.borderWidth,
-        stroke: this.item.style.borderColor,
-        fill: this.item.style.fillColor,
-        strokeDasharray: STROKE_DASHARRAY_MAP[this.item.style.borderStyle]
+        strokeWidth: item.value.style.borderWidth,
+        stroke: item.value.style.borderColor,
+        fill: item.value.style.fillColor,
+        strokeDasharray: STROKE_DASHARRAY_MAP[item.value.style.borderStyle]
       };
-    }
+    });
+
+    return {
+      style
+    };
   }
 });
 </script>

--- a/src/components/items/EllipseItemHighlighter.vue
+++ b/src/components/items/EllipseItemHighlighter.vue
@@ -10,33 +10,40 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { inverseScale } from '../../lib/inverse-scale';
 import { calcDiv, calcPlus } from '../../lib/strict-calculator';
 import { editor } from '../../store';
 import { EllipseItem } from '@/types';
 
-export default Vue.extend({
-  name: 'EllipseItemHeightlighter',
+export default defineComponent({
   props: {
     item: {
-      type: Object as PropType<EllipseItem>,
+      type: Object as () => EllipseItem,
       required: true
     }
   },
-  computed: {
-    rx (): number {
-      return calcPlus(this.item.rx, this.extraSize);
-    },
-    ry (): number {
-      return calcPlus(this.item.ry, this.extraSize);
-    },
-    strokeWidth (): number {
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const rx = computed((): number => {
+      return calcPlus(item.value.rx, extraSize.value);
+    });
+    const ry = computed((): number => {
+      return calcPlus(item.value.ry, extraSize.value);
+    });
+    const strokeWidth = computed((): number => {
       return inverseScale(3, editor.getters.zoomRate());
-    },
-    extraSize (): number {
-      return calcPlus(calcDiv(this.item.style.borderWidth, 2), calcDiv(this.strokeWidth, 2));
-    }
+    });
+    const extraSize = computed((): number => {
+      return calcPlus(calcDiv(item.value.style.borderWidth, 2), calcDiv(strokeWidth.value, 2));
+    });
+
+    return {
+      rx,
+      ry,
+      strokeWidth
+    };
   }
 });
 </script>

--- a/src/components/items/EllipseItemHighlighter.vue
+++ b/src/components/items/EllipseItemHighlighter.vue
@@ -26,17 +26,17 @@ export default defineComponent({
   setup (props) {
     const { item } = toRefs(props);
 
-    const rx = computed((): number => {
-      return calcPlus(item.value.rx, extraSize.value);
-    });
-    const ry = computed((): number => {
-      return calcPlus(item.value.ry, extraSize.value);
-    });
     const strokeWidth = computed((): number => {
       return inverseScale(3, editor.getters.zoomRate());
     });
     const extraSize = computed((): number => {
       return calcPlus(calcDiv(item.value.style.borderWidth, 2), calcDiv(strokeWidth.value, 2));
+    });
+    const rx = computed((): number => {
+      return calcPlus(item.value.rx, extraSize.value);
+    });
+    const ry = computed((): number => {
+      return calcPlus(item.value.ry, extraSize.value);
     });
 
     return {

--- a/src/components/items/EllipseItemOutline.vue
+++ b/src/components/items/EllipseItemOutline.vue
@@ -25,17 +25,17 @@ export default defineComponent({
   setup (props) {
     const { boundingBox } = toRefs(props);
 
-    const cx = computed((): EllipseItem['cx'] => {
-      return boundingBox.value.x + rx.value;
-    });
-    const cy = computed((): EllipseItem['cy'] => {
-      return boundingBox.value.y + ry.value;
-    });
     const rx = computed((): EllipseItem['rx'] => {
       return boundingBox.value.width / 2;
     });
     const ry = computed((): EllipseItem['ry'] => {
       return boundingBox.value.height / 2;
+    });
+    const cx = computed((): EllipseItem['cx'] => {
+      return boundingBox.value.x + rx.value;
+    });
+    const cy = computed((): EllipseItem['cy'] => {
+      return boundingBox.value.y + ry.value;
     });
     const strokeWidth = computed((): number => {
       return inverseScale(1, editor.getters.zoomRate());

--- a/src/components/items/EllipseItemOutline.vue
+++ b/src/components/items/EllipseItemOutline.vue
@@ -10,35 +10,44 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { inverseScale } from '@/lib/inverse-scale';
 import { editor } from '@/store';
 import { BoundingBox, EllipseItem } from '@/types';
 
-export default Vue.extend({
-  name: 'EllipseItemOutline',
+export default defineComponent({
   props: {
     boundingBox: {
-      type: Object as PropType<BoundingBox>,
+      type: Object as () => BoundingBox,
       required: true
     }
   },
-  computed: {
-    cx (): EllipseItem['cx'] {
-      return this.boundingBox.x + this.rx;
-    },
-    cy (): EllipseItem['cy'] {
-      return this.boundingBox.y + this.ry;
-    },
-    rx (): EllipseItem['rx'] {
-      return this.boundingBox.width / 2;
-    },
-    ry (): EllipseItem['ry'] {
-      return this.boundingBox.height / 2;
-    },
-    strokeWidth (): number {
+  setup (props) {
+    const { boundingBox } = toRefs(props);
+
+    const cx = computed((): EllipseItem['cx'] => {
+      return boundingBox.value.x + rx.value;
+    });
+    const cy = computed((): EllipseItem['cy'] => {
+      return boundingBox.value.y + ry.value;
+    });
+    const rx = computed((): EllipseItem['rx'] => {
+      return boundingBox.value.width / 2;
+    });
+    const ry = computed((): EllipseItem['ry'] => {
+      return boundingBox.value.height / 2;
+    });
+    const strokeWidth = computed((): number => {
       return inverseScale(1, editor.getters.zoomRate());
-    }
+    });
+
+    return {
+      cx,
+      cy,
+      rx,
+      ry,
+      strokeWidth
+    };
   }
 });
 </script>

--- a/src/components/items/ImageBlockItem.vue
+++ b/src/components/items/ImageBlockItem.vue
@@ -13,15 +13,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { report } from '../../store';
 import BoxItemHighlighter from './BoxItemHighlighter.vue';
 import ImageBlockItemBody from './ImageBlockItemBody.vue';
 import ItemEntity from './ItemEntity.vue';
 import { ImageBlockItem } from '@/types';
 
-export default Vue.extend({
-  name: 'ImageBlockItem',
+export default defineComponent({
   components: {
     ItemEntity,
     ImageBlockItemBody,
@@ -29,22 +28,29 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<ImageBlockItem>,
+      type: Object as () => ImageBlockItem,
       required: true
     }
   },
-  computed: {
-    isActive (): boolean {
-      return report.getters.isActiveItem(this.item.uid);
-    }
-  },
-  methods: {
-    dragStart () {
-      this.$emit('itemDragStart', this.item);
-    },
-    activate () {
-      report.actions.activateEntity({ uid: this.item.uid, type: 'item' });
-    }
+  setup (props, { emit }) {
+    const { item } = toRefs(props);
+
+    const isActive = computed((): boolean => {
+      return report.getters.isActiveItem(item.value.uid);
+    });
+
+    const dragStart = () => {
+      emit('itemDragStart', item.value);
+    };
+    const activate = () => {
+      report.actions.activateEntity({ uid: item.value.uid, type: 'item' });
+    };
+
+    return {
+      isActive,
+      dragStart,
+      activate
+    };
   }
 });
 </script>

--- a/src/components/items/ImageBlockItemBody.vue
+++ b/src/components/items/ImageBlockItemBody.vue
@@ -31,32 +31,38 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { inverseScale } from '../../lib/inverse-scale';
 import { editor } from '../../store';
 import ItemIdLabel from './ItemIdLabel.vue';
 import { ImageBlockItem } from '@/types';
 
-export default Vue.extend({
-  name: 'ImageBlockItemBody',
+export default defineComponent({
   components: {
     ItemIdLabel
   },
   props: {
     item: {
-      type: Object as PropType<ImageBlockItem>,
+      type: Object as () => ImageBlockItem,
       required: true
     }
   },
-  computed: {
-    id (): string {
-      return this.item.id === '' ? 'no id' : this.item.id;
-    },
-    iconStyle () {
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const id = computed((): string => {
+      return item.value.id === '' ? 'no id' : item.value.id;
+    });
+    const iconStyle = computed(() => {
       return {
         fontSize: `${inverseScale(1.7, editor.getters.zoomRate())}rem`
       };
-    }
+    });
+
+    return {
+      id,
+      iconStyle
+    };
   }
 });
 </script>

--- a/src/components/items/ImageItem.vue
+++ b/src/components/items/ImageItem.vue
@@ -13,15 +13,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { report } from '../../store';
 import BoxItemHighlighter from './BoxItemHighlighter.vue';
 import ImageItemBody from './ImageItemBody.vue';
 import ItemEntity from './ItemEntity.vue';
 import { ImageItem } from '@/types';
 
-export default Vue.extend({
-  name: 'ImageItem',
+export default defineComponent({
   components: {
     ItemEntity,
     ImageItemBody,
@@ -29,22 +28,29 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<ImageItem>,
+      type: Object as () => ImageItem,
       required: true
     }
   },
-  computed: {
-    isActive (): boolean {
-      return report.getters.isActiveItem(this.item.uid);
-    }
-  },
-  methods: {
-    dragStart () {
-      this.$emit('itemDragStart', this.item);
-    },
-    activate () {
-      report.actions.activateEntity({ uid: this.item.uid, type: 'item' });
-    }
+  setup (props, { emit }) {
+    const { item } = toRefs(props);
+
+    const isActive = computed((): boolean => {
+      return report.getters.isActiveItem(item.value.uid);
+    });
+
+    const dragStart = () => {
+      emit('itemDragStart', item.value);
+    };
+    const activate = () => {
+      report.actions.activateEntity({ uid: item.value.uid, type: 'item' });
+    };
+
+    return {
+      isActive,
+      dragStart,
+      activate
+    };
   }
 });
 </script>

--- a/src/components/items/ImageItemBody.vue
+++ b/src/components/items/ImageItemBody.vue
@@ -11,22 +11,27 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { ImageItem } from '@/types';
 
-export default Vue.extend({
-  name: 'ImageItemBody',
+export default defineComponent({
   props: {
     item: {
-      type: Object as PropType<ImageItem>,
+      type: Object as () => ImageItem,
       required: true
     }
   },
-  computed: {
-    href (): string {
-      const data = this.item.data;
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const href = computed((): string => {
+      const data = item.value.data;
       return `data:${data.mimeType};base64,${data.base64}`;
-    }
+    });
+
+    return {
+      href
+    };
   }
 });
 </script>

--- a/src/components/items/ItemEntity.vue
+++ b/src/components/items/ItemEntity.vue
@@ -28,6 +28,12 @@ export default defineComponent({
       return editor.getters.isSelectMode();
     });
 
+    const emitItemClick = () => {
+      emit('itemClick');
+    };
+    const emitItemDrag = () => {
+      emit('itemDrag');
+    };
     const onPointerDown = () => {
       pointerDown.value = true;
       emitItemClick();
@@ -40,12 +46,6 @@ export default defineComponent({
     };
     const onPointerUp = () => {
       pointerDown.value = false;
-    };
-    const emitItemClick = () => {
-      emit('itemClick');
-    };
-    const emitItemDrag = () => {
-      emit('itemDrag');
     };
 
     return {

--- a/src/components/items/ItemEntity.vue
+++ b/src/components/items/ItemEntity.vue
@@ -10,52 +10,50 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, ref } from '@vue/composition-api';
 import { editor } from '../../store';
 import { AnyItem } from '@/types';
 
-type Data = {
-  pointerDown: boolean;
-};
-
-export default Vue.extend({
-  name: 'ItemEntity',
+export default defineComponent({
   props: {
     item: {
-      type: Object as PropType<AnyItem>,
+      type: Object as () => AnyItem,
       required: true
     }
   },
-  data (): Data {
-    return {
-      pointerDown: false
-    };
-  },
-  computed: {
-    isSelectMode (): boolean {
+  setup (_, { emit }) {
+    const pointerDown = ref<boolean>(false);
+
+    const isSelectMode = computed((): boolean => {
       return editor.getters.isSelectMode();
-    }
-  },
-  methods: {
-    onPointerDown () {
-      this.pointerDown = true;
-      this.emitItemClick();
-    },
-    onPointerMove () {
-      if (this.pointerDown) {
-        this.emitItemDrag();
-        this.pointerDown = false;
+    });
+
+    const onPointerDown = () => {
+      pointerDown.value = true;
+      emitItemClick();
+    };
+    const onPointerMove = () => {
+      if (pointerDown.value) {
+        emitItemDrag();
+        pointerDown.value = false;
       }
-    },
-    onPointerUp () {
-      this.pointerDown = false;
-    },
-    emitItemClick () {
-      this.$emit('itemClick');
-    },
-    emitItemDrag () {
-      this.$emit('itemDrag');
-    }
+    };
+    const onPointerUp = () => {
+      pointerDown.value = false;
+    };
+    const emitItemClick = () => {
+      emit('itemClick');
+    };
+    const emitItemDrag = () => {
+      emit('itemDrag');
+    };
+
+    return {
+      isSelectMode,
+      onPointerDown,
+      onPointerMove,
+      onPointerUp
+    };
   }
 });
 </script>

--- a/src/components/items/ItemIdLabel.vue
+++ b/src/components/items/ItemIdLabel.vue
@@ -11,12 +11,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { inverseScale } from '../../lib/inverse-scale';
 import { editor } from '../../store';
 
-export default Vue.extend({
-  name: 'ItemIdLabel',
+export default defineComponent({
   props: {
     label: {
       type: String,
@@ -31,14 +30,19 @@ export default Vue.extend({
       required: true
     }
   },
-  computed: {
-    zoomRate: () => editor.getters.zoomRate(),
-    fontSize (): number {
-      return inverseScale(10, this.zoomRate);
-    },
-    left (): number {
-      return inverseScale(3, this.zoomRate);
-    }
+  setup () {
+    const zoomRate = computed(() => editor.getters.zoomRate());
+    const fontSize = computed((): number => {
+      return inverseScale(10, zoomRate.value);
+    });
+    const left = computed((): number => {
+      return inverseScale(3, zoomRate.value);
+    });
+
+    return {
+      fontSize,
+      left
+    };
   }
 });
 </script>

--- a/src/components/items/ItemOutline.vue
+++ b/src/components/items/ItemOutline.vue
@@ -16,15 +16,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { BoundsTransformer } from '../../lib/bounds-transformer';
 import BoxItemOutline from './BoxItemOutline.vue';
 import EllipseItemOutline from './EllipseItemOutline.vue';
 import LineItemOutline from './LineItemOutline.vue';
 import { BoundingPoints, ItemType, BoundingBox } from '@/types';
 
-export default Vue.extend({
-  name: 'ItemOutline',
+export default defineComponent({
   components: {
     EllipseItemOutline,
     BoxItemOutline,
@@ -32,18 +31,24 @@ export default Vue.extend({
   },
   props: {
     itemType: {
-      type: String as PropType<ItemType>,
+      type: String as () => ItemType,
       required: true
     },
     boundingPoints: {
-      type: Object as PropType<BoundingPoints>,
+      type: Object as () => BoundingPoints,
       required: true
     }
   },
-  computed: {
-    boundingBox (): BoundingBox {
-      return new BoundsTransformer(this.boundingPoints).toBBox();
-    }
+  setup (props) {
+    const { boundingPoints } = toRefs(props);
+
+    const boundingBox = computed((): BoundingBox => {
+      return new BoundsTransformer(boundingPoints.value).toBBox();
+    });
+
+    return {
+      boundingBox
+    };
   }
 });
 </script>

--- a/src/components/items/LineItem.vue
+++ b/src/components/items/LineItem.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { report } from '../../store';
 import ItemEntity from './ItemEntity.vue';
 import LineItemBody from './LineItemBody.vue';
@@ -22,8 +22,7 @@ import LineItemHighligher from './LineItemHighligher.vue';
 import LineItemSelector from './LineItemSelector.vue';
 import { LineItem } from '@/types';
 
-export default Vue.extend({
-  name: 'LineItem',
+export default defineComponent({
   components: {
     ItemEntity,
     LineItemBody,
@@ -32,22 +31,29 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<LineItem>,
+      type: Object as () => LineItem,
       required: true
     }
   },
-  computed: {
-    isActive (): boolean {
-      return report.getters.isActiveItem(this.item.uid);
-    }
-  },
-  methods: {
-    dragStart () {
-      this.$emit('itemDragStart', this.item);
-    },
-    activate () {
-      report.actions.activateEntity({ uid: this.item.uid, type: 'item' });
-    }
+  setup (props, { emit }) {
+    const { item } = toRefs(props);
+
+    const isActive = computed((): boolean => {
+      return report.getters.isActiveItem(item.value.uid);
+    });
+
+    const dragStart = () => {
+      emit('itemDragStart', item.value);
+    };
+    const activate = () => {
+      report.actions.activateEntity({ uid: item.value.uid, type: 'item' });
+    };
+
+    return {
+      isActive,
+      dragStart,
+      activate
+    };
   }
 });
 </script>

--- a/src/components/items/LineItemBody.vue
+++ b/src/components/items/LineItemBody.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { LineItem } from '@/types';
 
 type Style = {
@@ -24,22 +24,27 @@ const STROKE_DASHARRAY_MAP = {
   dotted: '1,1'
 } as const;
 
-export default Vue.extend({
-  name: 'LineItemBody',
+export default defineComponent({
   props: {
     item: {
-      type: Object as PropType<LineItem>,
+      type: Object as () => LineItem,
       required: true
     }
   },
-  computed: {
-    style (): Style {
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const style = computed((): Style => {
       return {
-        strokeWidth: this.item.style.borderWidth,
-        stroke: this.item.style.borderColor,
-        strokeDasharray: STROKE_DASHARRAY_MAP[this.item.style.borderStyle]
+        strokeWidth: item.value.style.borderWidth,
+        stroke: item.value.style.borderColor,
+        strokeDasharray: STROKE_DASHARRAY_MAP[item.value.style.borderStyle]
       };
-    }
+    });
+
+    return {
+      style
+    };
   }
 });
 </script>

--- a/src/components/items/LineItemHighligher.vue
+++ b/src/components/items/LineItemHighligher.vue
@@ -10,23 +10,28 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { inverseScale } from '../../lib/inverse-scale';
 import { editor } from '../../store';
 import { LineItem } from '@/types';
 
-export default Vue.extend({
-  name: 'LineItemHeightlighter',
+export default defineComponent({
   props: {
     item: {
-      type: Object as PropType<LineItem>,
+      type: Object as () => LineItem,
       required: true
     }
   },
-  computed: {
-    strokeWidth (): number {
-      return this.item.style.borderWidth + inverseScale(5, editor.getters.zoomRate());
-    }
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const strokeWidth = computed((): number => {
+      return item.value.style.borderWidth + inverseScale(5, editor.getters.zoomRate());
+    });
+
+    return {
+      strokeWidth
+    };
   }
 });
 </script>

--- a/src/components/items/LineItemOutline.vue
+++ b/src/components/items/LineItemOutline.vue
@@ -10,23 +10,26 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { inverseScale } from '../../lib/inverse-scale';
 import { editor } from '@/store';
 import { BoundingPoints } from '@/types';
 
-export default Vue.extend({
-  name: 'LineItemOutline',
+export default defineComponent({
   props: {
     boundingPoints: {
-      type: Object as PropType<BoundingPoints>,
+      type: Object as () => BoundingPoints,
       required: true
     }
   },
-  computed: {
-    strokeWidth (): number {
+  setup () {
+    const strokeWidth = computed((): number => {
       return inverseScale(1, editor.getters.zoomRate());
-    }
+    });
+
+    return {
+      strokeWidth
+    };
   }
 });
 </script>

--- a/src/components/items/LineItemSelector.vue
+++ b/src/components/items/LineItemSelector.vue
@@ -10,23 +10,26 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { inverseScale } from '../../lib/inverse-scale';
 import { editor } from '../../store';
 import { LineItem } from '@/types';
 
-export default Vue.extend({
-  name: 'LineItemSelector',
+export default defineComponent({
   props: {
     item: {
-      type: Object as PropType<LineItem>,
+      type: Object as () => LineItem,
       required: true
     }
   },
-  computed: {
-    strokeWidth (): number {
+  setup () {
+    const strokeWidth = computed((): number => {
       return inverseScale(10, editor.getters.zoomRate());
-    }
+    });
+
+    return {
+      strokeWidth
+    };
   }
 });
 </script>

--- a/src/components/items/RectItem.vue
+++ b/src/components/items/RectItem.vue
@@ -15,15 +15,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { report } from '../../store';
 import BoxItemHighlighter from './BoxItemHighlighter.vue';
 import ItemEntity from './ItemEntity.vue';
 import RectItemBody from './RectItemBody.vue';
 import { RectItem } from '@/types';
 
-export default Vue.extend({
-  name: 'RectItem',
+export default defineComponent({
   components: {
     ItemEntity,
     BoxItemHighlighter,
@@ -31,22 +30,29 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<RectItem>,
+      type: Object as () => RectItem,
       required: true
     }
   },
-  computed: {
-    isActive (): boolean {
-      return report.getters.isActiveItem(this.item.uid);
-    }
-  },
-  methods: {
-    dragStart () {
-      this.$emit('itemDragStart', this.item);
-    },
-    activate () {
-      report.actions.activateEntity({ uid: this.item.uid, type: 'item' });
-    }
+  setup (props, { emit }) {
+    const { item } = toRefs(props);
+
+    const isActive = computed((): boolean => {
+      return report.getters.isActiveItem(item.value.uid);
+    });
+
+    const dragStart = () => {
+      emit('itemDragStart', item.value);
+    };
+    const activate = () => {
+      report.actions.activateEntity({ uid: item.value.uid, type: 'item' });
+    };
+
+    return {
+      isActive,
+      dragStart,
+      activate
+    };
   }
 });
 </script>

--- a/src/components/items/RectItemBody.vue
+++ b/src/components/items/RectItemBody.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { RectItem } from '@/types';
 
 type Style = {
@@ -27,25 +27,30 @@ const STROKE_DASHARRAY_MAP = {
   dotted: '1,1'
 } as const;
 
-export default Vue.extend({
-  name: 'RectItemBody',
+export default defineComponent({
   props: {
     item: {
-      type: Object as PropType<RectItem>,
+      type: Object as () => RectItem,
       required: true
     }
   },
-  computed: {
-    style (): Style {
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const style = computed((): Style => {
       return {
-        strokeWidth: this.item.style.borderWidth,
-        stroke: this.item.style.borderColor,
-        fill: this.item.style.fillColor,
-        strokeDasharray: STROKE_DASHARRAY_MAP[this.item.style.borderStyle],
-        rx: this.item.borderRadius,
-        ry: this.item.borderRadius
+        strokeWidth: item.value.style.borderWidth,
+        stroke: item.value.style.borderColor,
+        fill: item.value.style.fillColor,
+        strokeDasharray: STROKE_DASHARRAY_MAP[item.value.style.borderStyle],
+        rx: item.value.borderRadius,
+        ry: item.value.borderRadius
       };
-    }
+    });
+
+    return {
+      style
+    };
   }
 });
 </script>

--- a/src/components/items/StackViewItemBody.vue
+++ b/src/components/items/StackViewItemBody.vue
@@ -12,23 +12,26 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { inverseScale } from '../../lib/inverse-scale';
 import { editor } from '../../store';
 import { BoundingBox } from '@/types';
 
-export default Vue.extend({
-  name: 'StackViewItemBody',
+export default defineComponent({
   props: {
     itemBounds: {
-      type: Object as PropType<BoundingBox>,
+      type: Object as () => BoundingBox,
       required: true
     }
   },
-  computed: {
-    strokeWidth (): number {
+  setup () {
+    const strokeWidth = computed((): number => {
       return inverseScale(1, editor.getters.zoomRate());
-    }
+    });
+
+    return {
+      strokeWidth
+    };
   }
 });
 </script>

--- a/src/components/items/StackViewItemModifier.vue
+++ b/src/components/items/StackViewItemModifier.vue
@@ -30,6 +30,9 @@ export default defineComponent({
 
     const pointerDown = ref<boolean>(false);
 
+    const frameWidth = computed(() => {
+      return inverseScale(10, editor.getters.zoomRate());
+    });
     const bounds = computed((): BoundingBox => {
       return {
         x: itemBounds.value.x - frameWidth.value / 2,
@@ -38,10 +41,13 @@ export default defineComponent({
         height: itemBounds.value.height + frameWidth.value
       };
     });
-    const frameWidth = computed(() => {
-      return inverseScale(10, editor.getters.zoomRate());
-    });
 
+    const emitModifierClick = () => {
+      emit('modifierClick');
+    };
+    const emitModifierDrag = () => {
+      emit('modifierDrag');
+    };
     const onPointerDown = () => {
       pointerDown.value = true;
     };
@@ -56,12 +62,6 @@ export default defineComponent({
         emitModifierClick();
       }
       pointerDown.value = false;
-    };
-    const emitModifierClick = () => {
-      emit('modifierClick');
-    };
-    const emitModifierDrag = () => {
-      emit('modifierDrag');
     };
 
     return {

--- a/src/components/items/StackViewItemModifier.vue
+++ b/src/components/items/StackViewItemModifier.vue
@@ -13,63 +13,64 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, ref, toRefs } from '@vue/composition-api';
 import { inverseScale } from '../../lib/inverse-scale';
 import { editor } from '../../store';
 import { BoundingBox } from '@/types';
 
-type Data = {
-  pointerDown: boolean;
-};
-
-export default Vue.extend({
-  name: 'StackViewItemModifier',
+export default defineComponent({
   props: {
     itemBounds: {
-      type: Object as PropType<BoundingBox>,
+      type: Object as () => BoundingBox,
       required: true
     }
   },
-  data (): Data {
-    return {
-      pointerDown: false
-    };
-  },
-  computed: {
-    bounds (): BoundingBox {
+  setup (props, { emit }) {
+    const { itemBounds } = toRefs(props);
+
+    const pointerDown = ref<boolean>(false);
+
+    const bounds = computed((): BoundingBox => {
       return {
-        x: this.itemBounds.x - this.frameWidth / 2,
-        y: this.itemBounds.y - this.frameWidth / 2,
-        width: this.itemBounds.width + this.frameWidth,
-        height: this.itemBounds.height + this.frameWidth
+        x: itemBounds.value.x - frameWidth.value / 2,
+        y: itemBounds.value.y - frameWidth.value / 2,
+        width: itemBounds.value.width + frameWidth.value,
+        height: itemBounds.value.height + frameWidth.value
       };
-    },
-    frameWidth () {
+    });
+    const frameWidth = computed(() => {
       return inverseScale(10, editor.getters.zoomRate());
-    }
-  },
-  methods: {
-    onPointerDown () {
-      this.pointerDown = true;
-    },
-    onPointerMove () {
-      if (this.pointerDown) {
-        this.emitModifierDrag();
-        this.pointerDown = false;
+    });
+
+    const onPointerDown = () => {
+      pointerDown.value = true;
+    };
+    const onPointerMove = () => {
+      if (pointerDown.value) {
+        emitModifierDrag();
+        pointerDown.value = false;
       }
-    },
-    onPointerUp () {
-      if (this.pointerDown) {
-        this.emitModifierClick();
+    };
+    const onPointerUp = () => {
+      if (pointerDown.value) {
+        emitModifierClick();
       }
-      this.pointerDown = false;
-    },
-    emitModifierClick () {
-      this.$emit('modifierClick');
-    },
-    emitModifierDrag () {
-      this.$emit('modifierDrag');
-    }
+      pointerDown.value = false;
+    };
+    const emitModifierClick = () => {
+      emit('modifierClick');
+    };
+    const emitModifierDrag = () => {
+      emit('modifierDrag');
+    };
+
+    return {
+      bounds,
+      frameWidth,
+      onPointerDown,
+      onPointerMove,
+      onPointerUp
+    };
   }
 });
 </script>

--- a/src/components/items/StackViewItemRow.vue
+++ b/src/components/items/StackViewItemRow.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, toRefs } from '@vue/composition-api';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { calcPlus } from '../../lib/strict-calculator';
 import { report, operator, editor } from '../../store';
 import CanvasDrawer from '../base/CanvasDrawer.vue';
@@ -67,14 +67,12 @@ export default defineComponent({
   setup (props) {
     const { row, bounds, sectionTranslation } = toRefs(props);
 
-    const pointerDown = ref(false);
-
     const isDrawMode = computed(() => editor.getters.isDrawMode());
-    const transform = computed((): string => {
-      return `translate(${Object.values(translation.value).join(',')})`;
-    });
     const translation = computed((): Translation => {
       return { x: bounds.value.x, y: bounds.value.y };
+    });
+    const transform = computed((): string => {
+      return `translate(${Object.values(translation.value).join(',')})`;
     });
     const translationByReport = computed((): Translation => {
       return {

--- a/src/components/items/StackViewItemRow.vue
+++ b/src/components/items/StackViewItemRow.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, ref, toRefs } from '@vue/composition-api';
 import { calcPlus } from '../../lib/strict-calculator';
 import { report, operator, editor } from '../../store';
 import CanvasDrawer from '../base/CanvasDrawer.vue';
@@ -38,8 +38,7 @@ import TextBlockItem from './TextBlockItem.vue';
 import TextItem from './TextItem.vue';
 import { StackViewRow, AnyItem, ItemType, Translation, BoundingBox } from '@/types';
 
-export default Vue.extend({
-  name: 'StackViewItemRow',
+export default defineComponent({
   components: {
     RectItem,
     EllipseItem,
@@ -53,52 +52,50 @@ export default Vue.extend({
   },
   props: {
     row: {
-      type: Object as PropType<StackViewRow>,
+      type: Object as () => StackViewRow,
       required: true
     },
     bounds: {
-      type: Object as PropType<BoundingBox>,
+      type: Object as () => BoundingBox,
       required: true
     },
     sectionTranslation: {
-      type: Object as PropType<Translation>,
+      type: Object as () => Translation,
       required: true
     }
   },
-  data () {
-    return {
-      pointerDown: false
-    };
-  },
-  computed: {
-    isDrawMode: () => editor.getters.isDrawMode(),
-    transform (): string {
-      return `translate(${Object.values(this.translation).join(',')})`;
-    },
-    translation (): Translation {
-      return { x: this.bounds.x, y: this.bounds.y };
-    },
-    translationByReport (): Translation {
+  setup (props) {
+    const { row, bounds, sectionTranslation } = toRefs(props);
+
+    const pointerDown = ref(false);
+
+    const isDrawMode = computed(() => editor.getters.isDrawMode());
+    const transform = computed((): string => {
+      return `translate(${Object.values(translation.value).join(',')})`;
+    });
+    const translation = computed((): Translation => {
+      return { x: bounds.value.x, y: bounds.value.y };
+    });
+    const translationByReport = computed((): Translation => {
       return {
-        x: calcPlus(this.translation.x, this.sectionTranslation.x),
-        y: calcPlus(this.translation.y, this.sectionTranslation.y)
+        x: calcPlus(translation.value.x, sectionTranslation.value.x),
+        y: calcPlus(translation.value.y, sectionTranslation.value.y)
       };
-    },
-    isActive (): boolean {
-      return report.getters.isActiveStackViewRow(this.row.uid);
-    },
-    items (): AnyItem[] {
-      return this.row.items.map(uid => report.getters.findItem(uid));
-    }
-  },
-  methods: {
-    startDragItem (item: AnyItem) {
+    });
+    const isActive = computed((): boolean => {
+      return report.getters.isActiveStackViewRow(row.value.uid);
+    });
+    const items = computed((): AnyItem[] => {
+      return row.value.items.map(uid => report.getters.findItem(uid));
+    });
+
+    const startDragItem = (item: AnyItem) => {
       operator.actions.startItemDrag({
         itemUid: item.uid,
-        translation: this.translationByReport
+        translation: translationByReport.value
       });
-    },
-    startDrawItem () {
+    };
+    const startDrawItem = () => {
       const itemType = editor.state.activeTool as ItemType;
 
       if (itemType === 'stack-view') return;
@@ -106,10 +103,19 @@ export default Vue.extend({
       operator.actions.startItemDraw({
         itemType,
         targetType: 'stack-view-row',
-        targetUid: this.row.uid,
-        translation: this.translationByReport
+        targetUid: row.value.uid,
+        translation: translationByReport.value
       });
-    }
+    };
+
+    return {
+      isDrawMode,
+      transform,
+      isActive,
+      items,
+      startDragItem,
+      startDrawItem
+    };
   }
 });
 </script>

--- a/src/components/items/StackViewItemRowDivider.vue
+++ b/src/components/items/StackViewItemRowDivider.vue
@@ -10,13 +10,12 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { calcPlus } from '../../lib/strict-calculator';
 import { inverseScale } from '@/lib/inverse-scale';
 import { editor } from '@/store';
 
-export default Vue.extend({
-  name: 'StackViewItemRoweDivider',
+export default defineComponent({
   props: {
     top: {
       type: Number,
@@ -31,22 +30,32 @@ export default Vue.extend({
       required: true
     }
   },
-  computed: {
-    x1 (): number {
-      return this.left;
-    },
-    y1 (): number {
-      return this.top;
-    },
-    x2 (): number {
-      return calcPlus(this.left, this.width);
-    },
-    y2 (): number {
-      return this.top;
-    },
-    strokeWidth (): number {
+  setup (props) {
+    const { top, left, width } = toRefs(props);
+
+    const x1 = computed((): number => {
+      return left.value;
+    });
+    const y1 = computed((): number => {
+      return top.value;
+    });
+    const x2 = computed((): number => {
+      return calcPlus(left.value, width.value);
+    });
+    const y2 = computed((): number => {
+      return top.value;
+    });
+    const strokeWidth = computed((): number => {
       return inverseScale(1, editor.getters.zoomRate());
-    }
+    });
+
+    return {
+      x1,
+      y1,
+      x2,
+      y2,
+      strokeWidth
+    };
   }
 });
 </script>

--- a/src/components/items/StackViewItemRowHighlighter.vue
+++ b/src/components/items/StackViewItemRowHighlighter.vue
@@ -10,22 +10,25 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { inverseScale } from '@/lib/inverse-scale';
 import { editor } from '@/store';
 
-export default Vue.extend({
-  name: 'StackViewItemRowHighlighter',
+export default defineComponent({
   props: {
     height: {
       type: Number,
       required: true
     }
   },
-  computed: {
-    strokeWidth (): number {
+  setup () {
+    const strokeWidth = computed((): number => {
       return inverseScale(1, editor.getters.zoomRate());
-    }
+    });
+
+    return {
+      strokeWidth
+    };
   }
 });
 </script>

--- a/src/components/items/StackViewItemSelector.vue
+++ b/src/components/items/StackViewItemSelector.vue
@@ -9,14 +9,13 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import { StackViewItem } from '@/types';
 
-export default Vue.extend({
-  name: 'StackViewItemSelector',
+export default defineComponent({
   props: {
     item: {
-      type: Object as PropType<StackViewItem>,
+      type: Object as () => StackViewItem,
       required: true
     },
     height: {

--- a/src/components/items/TextBlockItem.vue
+++ b/src/components/items/TextBlockItem.vue
@@ -13,15 +13,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { report } from '../../store';
 import BoxItemHighlighter from './BoxItemHighlighter.vue';
 import ItemEntity from './ItemEntity.vue';
 import TextBlockItemBody from './TextBlockItemBody.vue';
 import { TextBlockItem } from '@/types';
 
-export default Vue.extend({
-  name: 'TextBlockItem',
+export default defineComponent({
   components: {
     ItemEntity,
     TextBlockItemBody,
@@ -29,22 +28,29 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<TextBlockItem>,
+      type: Object as () => TextBlockItem,
       required: true
     }
   },
-  computed: {
-    isActive (): boolean {
-      return report.getters.isActiveItem(this.item.uid);
-    }
-  },
-  methods: {
-    dragStart () {
-      this.$emit('itemDragStart', this.item);
-    },
-    activate () {
-      report.actions.activateEntity({ uid: this.item.uid, type: 'item' });
-    }
+  setup (props, { emit }) {
+    const { item } = toRefs(props);
+
+    const isActive = computed((): boolean => {
+      return report.getters.isActiveItem(item.value.uid);
+    });
+
+    const dragStart = () => {
+      emit('itemDragStart', item.value);
+    };
+    const activate = () => {
+      report.actions.activateEntity({ uid: item.value.uid, type: 'item' });
+    };
+
+    return {
+      isActive,
+      dragStart,
+      activate
+    };
   }
 });
 </script>

--- a/src/components/items/TextBlockItemBody.vue
+++ b/src/components/items/TextBlockItemBody.vue
@@ -16,18 +16,17 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import ItemIdLabel from './ItemIdLabel.vue';
 import { TextBlockItem } from '@/types';
 
-export default Vue.extend({
-  name: 'TextBlockItemBody',
+export default defineComponent({
   components: {
     ItemIdLabel
   },
   props: {
     item: {
-      type: Object as PropType<TextBlockItem>,
+      type: Object as () => TextBlockItem,
       required: true
     }
   }

--- a/src/components/items/TextItem.vue
+++ b/src/components/items/TextItem.vue
@@ -13,15 +13,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { report } from '../../store';
 import BoxItemHighlighter from './BoxItemHighlighter.vue';
 import ItemEntity from './ItemEntity.vue';
 import TextItemBody from './TextItemBody.vue';
 import { TextItem } from '@/types';
 
-export default Vue.extend({
-  name: 'TextItem',
+export default defineComponent({
   components: {
     ItemEntity,
     TextItemBody,
@@ -29,22 +28,29 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<TextItem>,
+      type: Object as () => TextItem,
       required: true
     }
   },
-  computed: {
-    isActive (): boolean {
-      return report.getters.isActiveItem(this.item.uid);
-    }
-  },
-  methods: {
-    dragStart () {
-      this.$emit('itemDragStart', this.item);
-    },
-    activate () {
-      report.actions.activateEntity({ uid: this.item.uid, type: 'item' });
-    }
+  setup (props, { emit }) {
+    const { item } = toRefs(props);
+
+    const isActive = computed((): boolean => {
+      return report.getters.isActiveItem(item.value.uid);
+    });
+
+    const dragStart = () => {
+      emit('itemDragStart', item.value);
+    };
+    const activate = () => {
+      report.actions.activateEntity({ uid: item.value.uid, type: 'item' });
+    };
+
+    return {
+      isActive,
+      dragStart,
+      activate
+    };
   }
 });
 </script>

--- a/src/components/items/TextItemBody.vue
+++ b/src/components/items/TextItemBody.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, nextTick, toRefs } from '@vue/composition-api';
 import { calcDiv, calcPlus, calcMul, calcMinus } from '../../lib/strict-calculator';
 import { report } from '../../store';
 import { TextItem } from '@/types';
@@ -40,43 +40,54 @@ type TextStyle = {
   textAnchor: 'start' | 'middle' | 'end';
 };
 
-export default Vue.extend({
-  name: 'TextItemBody',
+export default defineComponent({
   props: {
     item: {
-      type: Object as PropType<TextItem>,
+      type: Object as () => TextItem,
       required: true
     }
   },
-  computed: {
-    textStyle (): TextStyle {
+  watch: {
+    item: {
+      handler (newItem: TextItem, oldItem: TextItem) {
+        if (isAdjustingBoxWidthRequired(newItem, oldItem)) {
+          nextTick(() => adjustBoxWidth());
+        }
+      },
+      deep: true
+    }
+  },
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const textStyle = computed((): TextStyle => {
       return {
-        fontSize: `${this.item.style.fontSize}px`,
-        fontFamily: this.item.style.fontFamily.join(','),
-        fill: this.item.style.color,
-        fontWeight: this.fontWeight,
-        fontStyle: this.fontStyle,
-        textDecoration: this.textDecoration,
-        textAnchor: this.textAnchor,
-        letterSpacing: this.letterSpacing
+        fontSize: `${item.value.style.fontSize}px`,
+        fontFamily: item.value.style.fontFamily.join(','),
+        fill: item.value.style.color,
+        fontWeight: fontWeight.value,
+        fontStyle: fontStyle.value,
+        textDecoration: textDecoration.value,
+        textAnchor: textAnchor.value,
+        letterSpacing: letterSpacing.value
       };
-    },
-    fontWeight (): TextStyle['fontWeight'] {
-      return this.item.style.fontStyle.includes('bold') ? 'bold' : 'normal';
-    },
-    fontStyle (): TextStyle['fontStyle'] {
-      return this.item.style.fontStyle.includes('italic') ? 'italic' : 'normal';
-    },
-    textAnchor (): TextStyle['textAnchor'] {
-      switch (this.item.style.textAlign) {
+    });
+    const fontWeight = computed((): TextStyle['fontWeight'] => {
+      return item.value.style.fontStyle.includes('bold') ? 'bold' : 'normal';
+    });
+    const fontStyle = computed((): TextStyle['fontStyle'] => {
+      return item.value.style.fontStyle.includes('italic') ? 'italic' : 'normal';
+    });
+    const textAnchor = computed((): TextStyle['textAnchor'] => {
+      switch (item.value.style.textAlign) {
         case 'left': return 'start';
         case 'center': return 'middle';
         case 'right': return 'end';
         default: throw new Error('Invalid text align value');
       }
-    },
-    textDecoration (): TextStyle['textDecoration'] {
-      const fontStyles = this.item.style.fontStyle;
+    });
+    const textDecoration = computed((): TextStyle['textDecoration'] => {
+      const fontStyles = item.value.style.fontStyle;
 
       if (fontStyles.includes('underline') && fontStyles.includes('linethrough')) {
         return 'underline line-through';
@@ -87,46 +98,35 @@ export default Vue.extend({
       } else {
         return 'none';
       }
-    },
-    letterSpacing (): TextStyle['letterSpacing'] {
-      return this.item.style.letterSpacing !== '' ? `${this.item.style.letterSpacing}px` : 'normal';
-    },
-    calculatedX (): number {
-      switch (this.textAnchor) {
-        case 'start': return this.item.x;
-        case 'middle': return calcPlus(this.item.x, calcDiv(this.item.width, 2));
-        case 'end': return calcPlus(this.item.x, this.item.width);
+    });
+    const letterSpacing = computed((): TextStyle['letterSpacing'] => {
+      return item.value.style.letterSpacing !== '' ? `${item.value.style.letterSpacing}px` : 'normal';
+    });
+    const calculatedX = computed((): number => {
+      switch (textAnchor.value) {
+        case 'start': return item.value.x;
+        case 'middle': return calcPlus(item.value.x, calcDiv(item.value.width, 2));
+        case 'end': return calcPlus(item.value.x, item.value.width);
         default: throw new Error('Invalid text align value');
       }
-    },
-    calculatedY (): number {
-      switch (this.item.style.verticalAlign) {
-        case 'top': return this.item.y;
-        case 'middle': return calcPlus(this.item.y, calcDiv(calcMinus(this.item.height, this.item.contentHeight), 2));
-        case 'bottom': return calcMinus(calcPlus(this.item.y, this.item.height), this.item.contentHeight);
+    });
+    const calculatedY = computed((): number => {
+      switch (item.value.style.verticalAlign) {
+        case 'top': return item.value.y;
+        case 'middle': return calcPlus(item.value.y, calcDiv(calcMinus(item.value.height, item.value.contentHeight), 2));
+        case 'bottom': return calcMinus(calcPlus(item.value.y, item.value.height), item.value.contentHeight);
         default: throw new Error('Invalid vertical align value');
       }
-    }
-  },
-  watch: {
-    item: {
-      handler (newItem: TextItem, oldItem: TextItem) {
-        if (this.isAdjustingBoxWidthRequired(newItem, oldItem)) {
-          this.$nextTick(() => this.adjustBoxWidth());
-        }
-      },
-      deep: true
-    }
-  },
-  methods: {
-    calculateTextLineY (index: number) {
-      return calcPlus(this.calculatedY, calcMul(this.item.style.lineHeight, index));
-    },
-    adjustBoxWidth () {
+    });
+
+    const calculateTextLineY = (index: number) => {
+      return calcPlus(calculatedY.value, calcMul(item.value.style.lineHeight, index));
+    };
+    const adjustBoxWidth = () => {
       const bbox = (this.$refs.box as SVGGElement).getBBox();
-      report.actions.adjustTextItemWidth({ uid: this.item.uid, minWidth: bbox.width });
-    },
-    isAdjustingBoxWidthRequired (item: TextItem, prevItem: TextItem): boolean {
+      report.actions.adjustTextItemWidth({ uid: item.value.uid, minWidth: bbox.width });
+    };
+    const isAdjustingBoxWidthRequired = (item: TextItem, prevItem: TextItem): boolean => {
       const itemStyle = item.style;
       const prevItemStyle = prevItem.style;
 
@@ -138,7 +138,13 @@ export default Vue.extend({
         item.texts.join() !== prevItem.texts.join() ||
         itemStyle.letterSpacing !== prevItemStyle.letterSpacing
       );
-    }
+    };
+
+    return {
+      textStyle,
+      calculatedX,
+      calculateTextLineY
+    };
   }
 });
 </script>

--- a/src/components/property/DetailSectionProperties.vue
+++ b/src/components/property/DetailSectionProperties.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import PropertyCaption from './PropertyCaption.vue';
 import AutoStretchProperty from './properties/AutoStretchProperty.vue';
 import HeightProperty from './properties/HeightProperty.vue';
@@ -25,8 +25,7 @@ import IdProperty from './properties/IdProperty.vue';
 import { report } from '@/store';
 import { DetailSection } from '@/types';
 
-export default Vue.extend({
-  name: 'DetailSectionProperties',
+export default defineComponent({
   components: {
     AutoStretchProperty,
     HeightProperty,
@@ -35,20 +34,28 @@ export default Vue.extend({
   },
   props: {
     section: {
-      type: Object as PropType<DetailSection>,
+      type: Object as () => DetailSection,
       required: true
     }
   },
-  methods: {
-    updateId (value: string) {
-      report.actions.updateDetailSection({ sectionUid: this.section.uid, key: 'id', value });
-    },
-    updateHeight (value: number) {
-      report.actions.updateDetailSection({ sectionUid: this.section.uid, key: 'height', value });
-    },
-    updateAutoStretch (value: boolean) {
-      report.actions.updateDetailSection({ sectionUid: this.section.uid, key: 'autoStretch', value });
-    }
+  setup (props) {
+    const { section } = toRefs(props);
+
+    const updateId = (value: string) => {
+      report.actions.updateDetailSection({ sectionUid: section.value.uid, key: 'id', value });
+    };
+    const updateHeight = (value: number) => {
+      report.actions.updateDetailSection({ sectionUid: section.value.uid, key: 'height', value });
+    };
+    const updateAutoStretch = (value: boolean) => {
+      report.actions.updateDetailSection({ sectionUid: section.value.uid, key: 'autoStretch', value });
+    };
+
+    return {
+      updateId,
+      updateHeight,
+      updateAutoStretch
+    };
   }
 });
 </script>

--- a/src/components/property/EllipseItemProperties.vue
+++ b/src/components/property/EllipseItemProperties.vue
@@ -116,6 +116,10 @@ export default defineComponent({
     const updateDisplay = (value: boolean) => {
       report.actions.updateEllipseItem({ uid: item.value.uid, key: 'display', value });
     };
+    const updateBounds = (bounds: Bounds) => {
+      const bPoints = BoundsTransformer.fromBBox(bounds).toBPoints();
+      report.actions.updateEllipseItemBounds(item.value.uid, bPoints);
+    };
     const updateX = (value: string) => {
       updateBounds({ ...bounds.value, x: Number(value) });
     };
@@ -127,10 +131,6 @@ export default defineComponent({
     };
     const updateHeight = (value: string) => {
       updateBounds({ ...bounds.value, height: Number(value) });
-    };
-    const updateBounds = (bounds: Bounds) => {
-      const bPoints = BoundsTransformer.fromBBox(bounds).toBPoints();
-      report.actions.updateEllipseItemBounds(item.value.uid, bPoints);
     };
     const updateFollowStretch = (value: EllipseItem['followStretch']) => {
       report.actions.updateEllipseItem({ uid: item.value.uid, key: 'followStretch', value });

--- a/src/components/property/EllipseItemProperties.vue
+++ b/src/components/property/EllipseItemProperties.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import PropertyCaption from './PropertyCaption.vue';
 import AffectBottomMarginProperty from './properties/AffectBottomMarginProperty.vue';
 import DescriptionProperty from './properties/DescriptionProperty.vue';
@@ -76,8 +76,7 @@ import { BoundsTransformer } from '@/lib/bounds-transformer';
 import { report } from '@/store';
 import { EllipseItem, Bounds, BoundingBox } from '@/types';
 
-export default Vue.extend({
-  name: 'EllipseItemProperties',
+export default defineComponent({
   components: {
     DisplayProperty,
     IdProperty,
@@ -96,60 +95,78 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<EllipseItem>,
+      type: Object as () => EllipseItem,
       required: true
     }
   },
-  computed: {
-    bounds (): BoundingBox {
-      const bounds = report.getters.itemBounds(this.item.uid);
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const bounds = computed((): BoundingBox => {
+      const bounds = report.getters.itemBounds(item.value.uid);
       return new BoundsTransformer(bounds).toBBox();
-    }
-  },
-  methods: {
-    updateId (value: string) {
-      report.actions.updateEllipseItem({ uid: this.item.uid, key: 'id', value });
-    },
-    updateDescription (value: string) {
-      report.actions.updateEllipseItem({ uid: this.item.uid, key: 'description', value });
-    },
-    updateDisplay (value: boolean) {
-      report.actions.updateEllipseItem({ uid: this.item.uid, key: 'display', value });
-    },
-    updateX (value: string) {
-      this.updateBounds({ ...this.bounds, x: Number(value) });
-    },
-    updateY (value: string) {
-      this.updateBounds({ ...this.bounds, y: Number(value) });
-    },
-    updateWidth (value: string) {
-      this.updateBounds({ ...this.bounds, width: Number(value) });
-    },
-    updateHeight (value: string) {
-      this.updateBounds({ ...this.bounds, height: Number(value) });
-    },
-    updateBounds (bounds: Bounds) {
+    });
+
+    const updateId = (value: string) => {
+      report.actions.updateEllipseItem({ uid: item.value.uid, key: 'id', value });
+    };
+    const updateDescription = (value: string) => {
+      report.actions.updateEllipseItem({ uid: item.value.uid, key: 'description', value });
+    };
+    const updateDisplay = (value: boolean) => {
+      report.actions.updateEllipseItem({ uid: item.value.uid, key: 'display', value });
+    };
+    const updateX = (value: string) => {
+      updateBounds({ ...bounds.value, x: Number(value) });
+    };
+    const updateY = (value: string) => {
+      updateBounds({ ...bounds.value, y: Number(value) });
+    };
+    const updateWidth = (value: string) => {
+      updateBounds({ ...bounds.value, width: Number(value) });
+    };
+    const updateHeight = (value: string) => {
+      updateBounds({ ...bounds.value, height: Number(value) });
+    };
+    const updateBounds = (bounds: Bounds) => {
       const bPoints = BoundsTransformer.fromBBox(bounds).toBPoints();
-      report.actions.updateEllipseItemBounds(this.item.uid, bPoints);
-    },
-    updateFollowStretch (value: EllipseItem['followStretch']) {
-      report.actions.updateEllipseItem({ uid: this.item.uid, key: 'followStretch', value });
-    },
-    updateAffectBottomMargin (value: boolean) {
-      report.actions.updateEllipseItem({ uid: this.item.uid, key: 'affectBottomMargin', value });
-    },
-    updateFillColor (value: string) {
-      report.actions.updateEllipseItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, fillColor: value } });
-    },
-    updateBorderColor (value: string) {
-      report.actions.updateEllipseItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, borderColor: value } });
-    },
-    updateBorderWidth (value: string) {
-      report.actions.updateEllipseItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, borderWidth: Number(value) } });
-    },
-    updateBorderStyle (value: EllipseItem['style']['borderStyle']) {
-      report.actions.updateEllipseItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, borderStyle: value } });
-    }
+      report.actions.updateEllipseItemBounds(item.value.uid, bPoints);
+    };
+    const updateFollowStretch = (value: EllipseItem['followStretch']) => {
+      report.actions.updateEllipseItem({ uid: item.value.uid, key: 'followStretch', value });
+    };
+    const updateAffectBottomMargin = (value: boolean) => {
+      report.actions.updateEllipseItem({ uid: item.value.uid, key: 'affectBottomMargin', value });
+    };
+    const updateFillColor = (value: string) => {
+      report.actions.updateEllipseItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, fillColor: value } });
+    };
+    const updateBorderColor = (value: string) => {
+      report.actions.updateEllipseItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, borderColor: value } });
+    };
+    const updateBorderWidth = (value: string) => {
+      report.actions.updateEllipseItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, borderWidth: Number(value) } });
+    };
+    const updateBorderStyle = (value: EllipseItem['style']['borderStyle']) => {
+      report.actions.updateEllipseItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, borderStyle: value } });
+    };
+
+    return {
+      bounds,
+      updateId,
+      updateDescription,
+      updateDisplay,
+      updateX,
+      updateY,
+      updateWidth,
+      updateHeight,
+      updateFollowStretch,
+      updateAffectBottomMargin,
+      updateFillColor,
+      updateBorderColor,
+      updateBorderWidth,
+      updateBorderStyle
+    };
   }
 });
 </script>

--- a/src/components/property/FooterSectionProperties.vue
+++ b/src/components/property/FooterSectionProperties.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import PropertyCaption from './PropertyCaption.vue';
 import AutoStretchProperty from './properties/AutoStretchProperty.vue';
 import DisplayProperty from './properties/DisplayProperty.vue';
@@ -30,8 +30,7 @@ import IdProperty from './properties/IdProperty.vue';
 import { report } from '@/store';
 import { FooterSection } from '@/types';
 
-export default Vue.extend({
-  name: 'FooterSectionProperties',
+export default defineComponent({
   components: {
     IdProperty,
     AutoStretchProperty,
@@ -41,23 +40,32 @@ export default Vue.extend({
   },
   props: {
     section: {
-      type: Object as PropType<FooterSection>,
+      type: Object as () => FooterSection,
       required: true
     }
   },
-  methods: {
-    updateId (value: string) {
-      report.actions.updateFooterSection({ sectionUid: this.section.uid, key: 'id', value });
-    },
-    updateDisplay (value: boolean) {
-      report.actions.updateFooterSection({ sectionUid: this.section.uid, key: 'display', value });
-    },
-    updateHeight (value: number) {
-      report.actions.updateFooterSection({ sectionUid: this.section.uid, key: 'height', value });
-    },
-    updateAutoStretch (value: boolean) {
-      report.actions.updateFooterSection({ sectionUid: this.section.uid, key: 'autoStretch', value });
-    }
+  setup (props) {
+    const { section } = toRefs(props);
+
+    const updateId = (value: string) => {
+      report.actions.updateFooterSection({ sectionUid: section.value.uid, key: 'id', value });
+    };
+    const updateDisplay = (value: boolean) => {
+      report.actions.updateFooterSection({ sectionUid: section.value.uid, key: 'display', value });
+    };
+    const updateHeight = (value: number) => {
+      report.actions.updateFooterSection({ sectionUid: section.value.uid, key: 'height', value });
+    };
+    const updateAutoStretch = (value: boolean) => {
+      report.actions.updateFooterSection({ sectionUid: section.value.uid, key: 'autoStretch', value });
+    };
+
+    return {
+      updateId,
+      updateDisplay,
+      updateHeight,
+      updateAutoStretch
+    };
   }
 });
 </script>

--- a/src/components/property/HeaderSectionProperties.vue
+++ b/src/components/property/HeaderSectionProperties.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import PropertyCaption from './PropertyCaption.vue';
 import AutoStretchProperty from './properties/AutoStretchProperty.vue';
 import DisplayProperty from './properties/DisplayProperty.vue';
@@ -35,8 +35,7 @@ import IdProperty from './properties/IdProperty.vue';
 import { report } from '@/store';
 import { HeaderSection } from '@/types';
 
-export default Vue.extend({
-  name: 'HeaderSectionProperties',
+export default defineComponent({
   components: {
     AutoStretchProperty,
     DisplayProperty,
@@ -47,26 +46,36 @@ export default Vue.extend({
   },
   props: {
     section: {
-      type: Object as PropType<HeaderSection>,
+      type: Object as () => HeaderSection,
       required: true
     }
   },
-  methods: {
-    updateId (value: string) {
-      report.actions.updateHeaderSection({ sectionUid: this.section.uid, key: 'id', value });
-    },
-    updateDisplay (value: boolean) {
-      report.actions.updateHeaderSection({ sectionUid: this.section.uid, key: 'display', value });
-    },
-    updateHeight (value: number) {
-      report.actions.updateHeaderSection({ sectionUid: this.section.uid, key: 'height', value });
-    },
-    updateAutoStretch (value: boolean) {
-      report.actions.updateHeaderSection({ sectionUid: this.section.uid, key: 'autoStretch', value });
-    },
-    updateEveryPage (value: boolean) {
-      report.actions.updateHeaderSection({ sectionUid: this.section.uid, key: 'everyPage', value });
-    }
+  setup (props) {
+    const { section } = toRefs(props);
+
+    const updateId = (value: string) => {
+      report.actions.updateHeaderSection({ sectionUid: section.value.uid, key: 'id', value });
+    };
+    const updateDisplay = (value: boolean) => {
+      report.actions.updateHeaderSection({ sectionUid: section.value.uid, key: 'display', value });
+    };
+    const updateHeight = (value: number) => {
+      report.actions.updateHeaderSection({ sectionUid: section.value.uid, key: 'height', value });
+    };
+    const updateAutoStretch = (value: boolean) => {
+      report.actions.updateHeaderSection({ sectionUid: section.value.uid, key: 'autoStretch', value });
+    };
+    const updateEveryPage = (value: boolean) => {
+      report.actions.updateHeaderSection({ sectionUid: section.value.uid, key: 'everyPage', value });
+    };
+
+    return {
+      updateId,
+      updateDisplay,
+      updateHeight,
+      updateAutoStretch,
+      updateEveryPage
+    };
   }
 });
 </script>

--- a/src/components/property/ImageBlockItemProperties.vue
+++ b/src/components/property/ImageBlockItemProperties.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import PropertyCaption from './PropertyCaption.vue';
 import AffectBottomMarginProperty from './properties/AffectBottomMarginProperty.vue';
 import DescriptionProperty from './properties/DescriptionProperty.vue';
@@ -65,8 +65,7 @@ import WidthProperty from './properties/WidthProperty.vue';
 import { report } from '@/store';
 import { ImageBlockItem } from '@/types';
 
-export default Vue.extend({
-  name: 'ImageBlockItemProperties',
+export default defineComponent({
   components: {
     DisplayProperty,
     IdProperty,
@@ -83,44 +82,60 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<ImageBlockItem>,
+      type: Object as () => ImageBlockItem,
       required: true
     }
   },
-  methods: {
-    updateId (value: string) {
-      report.actions.updateImageBlockItem({ uid: this.item.uid, key: 'id', value });
-    },
-    updateDescription (value: string) {
-      report.actions.updateImageBlockItem({ uid: this.item.uid, key: 'description', value });
-    },
-    updateDisplay (value: boolean) {
-      report.actions.updateImageBlockItem({ uid: this.item.uid, key: 'display', value });
-    },
-    updateHeight (value: string) {
-      report.actions.updateImageBlockItem({ uid: this.item.uid, key: 'height', value: Number(value) });
-    },
-    updateWidth (value: string) {
-      report.actions.updateImageBlockItem({ uid: this.item.uid, key: 'width', value: Number(value) });
-    },
-    updateX (value: string) {
-      report.actions.updateImageBlockItem({ uid: this.item.uid, key: 'x', value: Number(value) });
-    },
-    updateY (value: string) {
-      report.actions.updateImageBlockItem({ uid: this.item.uid, key: 'y', value: Number(value) });
-    },
-    updateFollowStretch (value: ImageBlockItem['followStretch']) {
-      report.actions.updateImageBlockItem({ uid: this.item.uid, key: 'followStretch', value });
-    },
-    updateAffectBottomMargin (value: boolean) {
-      report.actions.updateImageBlockItem({ uid: this.item.uid, key: 'affectBottomMargin', value });
-    },
-    updatePositionX (value: ImageBlockItem['style']['positionX']) {
-      report.actions.updateImageBlockItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, positionX: value } });
-    },
-    updatePositionY (value: ImageBlockItem['style']['positionY']) {
-      report.actions.updateImageBlockItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, positionY: value } });
-    }
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const updateId = (value: string) => {
+      report.actions.updateImageBlockItem({ uid: item.value.uid, key: 'id', value });
+    };
+    const updateDescription = (value: string) => {
+      report.actions.updateImageBlockItem({ uid: item.value.uid, key: 'description', value });
+    };
+    const updateDisplay = (value: boolean) => {
+      report.actions.updateImageBlockItem({ uid: item.value.uid, key: 'display', value });
+    };
+    const updateHeight = (value: string) => {
+      report.actions.updateImageBlockItem({ uid: item.value.uid, key: 'height', value: Number(value) });
+    };
+    const updateWidth = (value: string) => {
+      report.actions.updateImageBlockItem({ uid: item.value.uid, key: 'width', value: Number(value) });
+    };
+    const updateX = (value: string) => {
+      report.actions.updateImageBlockItem({ uid: item.value.uid, key: 'x', value: Number(value) });
+    };
+    const updateY = (value: string) => {
+      report.actions.updateImageBlockItem({ uid: item.value.uid, key: 'y', value: Number(value) });
+    };
+    const updateFollowStretch = (value: ImageBlockItem['followStretch']) => {
+      report.actions.updateImageBlockItem({ uid: item.value.uid, key: 'followStretch', value });
+    };
+    const updateAffectBottomMargin = (value: boolean) => {
+      report.actions.updateImageBlockItem({ uid: item.value.uid, key: 'affectBottomMargin', value });
+    };
+    const updatePositionX = (value: ImageBlockItem['style']['positionX']) => {
+      report.actions.updateImageBlockItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, positionX: value } });
+    };
+    const updatePositionY = (value: ImageBlockItem['style']['positionY']) => {
+      report.actions.updateImageBlockItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, positionY: value } });
+    };
+
+    return {
+      updateId,
+      updateDescription,
+      updateDisplay,
+      updateHeight,
+      updateWidth,
+      updateX,
+      updateY,
+      updateFollowStretch,
+      updateAffectBottomMargin,
+      updatePositionX,
+      updatePositionY
+    };
   }
 });
 </script>

--- a/src/components/property/ImageItemProperties.vue
+++ b/src/components/property/ImageItemProperties.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import PropertyCaption from './PropertyCaption.vue';
 import AffectBottomMarginProperty from './properties/AffectBottomMarginProperty.vue';
 import DescriptionProperty from './properties/DescriptionProperty.vue';
@@ -55,8 +55,7 @@ import WidthProperty from './properties/WidthProperty.vue';
 import { report } from '@/store';
 import { ImageItem } from '@/types';
 
-export default Vue.extend({
-  name: 'ImageItemProperties',
+export default defineComponent({
   components: {
     DisplayProperty,
     IdProperty,
@@ -71,38 +70,52 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<ImageItem>,
+      type: Object as () => ImageItem,
       required: true
     }
   },
-  methods: {
-    updateId (value: string) {
-      report.actions.updateImageItem({ uid: this.item.uid, key: 'id', value });
-    },
-    updateDescription (value: string) {
-      report.actions.updateImageItem({ uid: this.item.uid, key: 'description', value });
-    },
-    updateDisplay (value: boolean) {
-      report.actions.updateImageItem({ uid: this.item.uid, key: 'display', value });
-    },
-    updateHeight (value: string) {
-      report.actions.updateImageItem({ uid: this.item.uid, key: 'height', value: Number(value) });
-    },
-    updateWidth (value: string) {
-      report.actions.updateImageItem({ uid: this.item.uid, key: 'width', value: Number(value) });
-    },
-    updateX (value: string) {
-      report.actions.updateImageItem({ uid: this.item.uid, key: 'x', value: Number(value) });
-    },
-    updateY (value: string) {
-      report.actions.updateImageItem({ uid: this.item.uid, key: 'y', value: Number(value) });
-    },
-    updateFollowStretch (value: ImageItem['followStretch']) {
-      report.actions.updateImageItem({ uid: this.item.uid, key: 'followStretch', value });
-    },
-    updateAffectBottomMargin (value: boolean) {
-      report.actions.updateImageItem({ uid: this.item.uid, key: 'affectBottomMargin', value });
-    }
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const updateId = (value: string) => {
+      report.actions.updateImageItem({ uid: item.value.uid, key: 'id', value });
+    };
+    const updateDescription = (value: string) => {
+      report.actions.updateImageItem({ uid: item.value.uid, key: 'description', value });
+    };
+    const updateDisplay = (value: boolean) => {
+      report.actions.updateImageItem({ uid: item.value.uid, key: 'display', value });
+    };
+    const updateHeight = (value: string) => {
+      report.actions.updateImageItem({ uid: item.value.uid, key: 'height', value: Number(value) });
+    };
+    const updateWidth = (value: string) => {
+      report.actions.updateImageItem({ uid: item.value.uid, key: 'width', value: Number(value) });
+    };
+    const updateX = (value: string) => {
+      report.actions.updateImageItem({ uid: item.value.uid, key: 'x', value: Number(value) });
+    };
+    const updateY = (value: string) => {
+      report.actions.updateImageItem({ uid: item.value.uid, key: 'y', value: Number(value) });
+    };
+    const updateFollowStretch = (value: ImageItem['followStretch']) => {
+      report.actions.updateImageItem({ uid: item.value.uid, key: 'followStretch', value });
+    };
+    const updateAffectBottomMargin = (value: boolean) => {
+      report.actions.updateImageItem({ uid: item.value.uid, key: 'affectBottomMargin', value });
+    };
+
+    return {
+      updateId,
+      updateDescription,
+      updateDisplay,
+      updateHeight,
+      updateWidth,
+      updateX,
+      updateY,
+      updateFollowStretch,
+      updateAffectBottomMargin
+    };
   }
 });
 </script>

--- a/src/components/property/ItemProperties.vue
+++ b/src/components/property/ItemProperties.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import EllipseItemProperties from './EllipseItemProperties.vue';
 import ImageBlockItemProperties from './ImageBlockItemProperties.vue';
 import ImageItemProperties from './ImageItemProperties.vue';
@@ -47,8 +47,7 @@ import TextBlockItemProperties from './TextBlockItemProperties.vue';
 import TextItemProperties from './TextItemProperties.vue';
 import { AnyItem } from '@/types';
 
-export default Vue.extend({
-  name: 'ItemProperties',
+export default defineComponent({
   components: {
     RectItemProperties,
     EllipseItemProperties,
@@ -61,35 +60,48 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<AnyItem>,
+      type: Object as () => AnyItem,
       required: true
     }
   },
-  computed: {
-    isRectItem (): boolean {
-      return this.item.type === 'rect';
-    },
-    isEllipseItem (): boolean {
-      return this.item.type === 'ellipse';
-    },
-    isLineItem (): boolean {
-      return this.item.type === 'line';
-    },
-    isTextItem (): boolean {
-      return this.item.type === 'text';
-    },
-    isTextBlockItem (): boolean {
-      return this.item.type === 'text-block';
-    },
-    isImageItem (): boolean {
-      return this.item.type === 'image';
-    },
-    isImageBlockItem (): boolean {
-      return this.item.type === 'image-block';
-    },
-    isStackViewItem (): boolean {
-      return this.item.type === 'stack-view';
-    }
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const isRectItem = computed((): boolean => {
+      return item.value.type === 'rect';
+    });
+    const isEllipseItem = computed((): boolean => {
+      return item.value.type === 'ellipse';
+    });
+    const isLineItem = computed((): boolean => {
+      return item.value.type === 'line';
+    });
+    const isTextItem = computed((): boolean => {
+      return item.value.type === 'text';
+    });
+    const isTextBlockItem = computed((): boolean => {
+      return item.value.type === 'text-block';
+    });
+    const isImageItem = computed((): boolean => {
+      return item.value.type === 'image';
+    });
+    const isImageBlockItem = computed((): boolean => {
+      return item.value.type === 'image-block';
+    });
+    const isStackViewItem = computed((): boolean => {
+      return item.value.type === 'stack-view';
+    });
+
+    return {
+      isRectItem,
+      isEllipseItem,
+      isLineItem,
+      isTextItem,
+      isTextBlockItem,
+      isImageItem,
+      isImageBlockItem,
+      isStackViewItem
+    };
   }
 });
 </script>

--- a/src/components/property/LineItemProperties.vue
+++ b/src/components/property/LineItemProperties.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { round } from '../../lib/round-float-values';
 import PropertyCaption from './PropertyCaption.vue';
 import AffectBottomMarginProperty from './properties/AffectBottomMarginProperty.vue';
@@ -71,8 +71,7 @@ import WidthProperty from './properties/WidthProperty.vue';
 import { report } from '@/store';
 import { LineItem, Bounds } from '@/types';
 
-export default Vue.extend({
-  name: 'LineItemProperties',
+export default defineComponent({
   components: {
     DisplayProperty,
     IdProperty,
@@ -90,74 +89,91 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<LineItem>,
+      type: Object as () => LineItem,
       required: true
     }
   },
-  computed: {
-    bounds (): Bounds {
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const bounds = computed((): Bounds => {
       return {
-        x: this.isXDirectionPositive ? this.item.x1 : this.item.x2,
-        y: this.isYDirectionPositive ? this.item.y1 : this.item.y2,
-        width: round(Math.abs(this.item.x1 - this.item.x2)),
-        height: round(Math.abs(this.item.y1 - this.item.y2))
+        x: isXDirectionPositive.value ? item.value.x1 : item.value.x2,
+        y: isYDirectionPositive.value ? item.value.y1 : item.value.y2,
+        width: round(Math.abs(item.value.x1 - item.value.x2)),
+        height: round(Math.abs(item.value.y1 - item.value.y2))
       };
-    },
-    isXDirectionPositive (): boolean {
-      return this.item.x1 < this.item.x2;
-    },
-    isYDirectionPositive (): boolean {
-      return this.item.y1 < this.item.y2;
-    }
-  },
-  methods: {
-    updateId (value: string) {
-      report.actions.updateLineItem({ uid: this.item.uid, key: 'id', value });
-    },
-    updateDescription (value: string) {
-      report.actions.updateLineItem({ uid: this.item.uid, key: 'description', value });
-    },
-    updateDisplay (value: boolean) {
-      report.actions.updateLineItem({ uid: this.item.uid, key: 'display', value });
-    },
-    updateX (value: string) {
-      this.updateBounds({ ...this.bounds, x: Number(value) });
-    },
-    updateY (value: string) {
-      this.updateBounds({ ...this.bounds, y: Number(value) });
-    },
-    updateWidth (value: string) {
-      this.updateBounds({ ...this.bounds, width: Number(value) });
-    },
-    updateHeight (value: string) {
-      this.updateBounds({ ...this.bounds, height: Number(value) });
-    },
-    updateBounds (bounds: Bounds) {
+    });
+    const isXDirectionPositive = computed((): boolean => {
+      return item.value.x1 < item.value.x2;
+    });
+    const isYDirectionPositive = computed((): boolean => {
+      return item.value.y1 < item.value.y2;
+    });
+
+    const updateId = (value: string) => {
+      report.actions.updateLineItem({ uid: item.value.uid, key: 'id', value });
+    };
+    const updateDescription = (value: string) => {
+      report.actions.updateLineItem({ uid: item.value.uid, key: 'description', value });
+    };
+    const updateDisplay = (value: boolean) => {
+      report.actions.updateLineItem({ uid: item.value.uid, key: 'display', value });
+    };
+    const updateX = (value: string) => {
+      updateBounds({ ...bounds.value, x: Number(value) });
+    };
+    const updateY = (value: string) => {
+      updateBounds({ ...bounds.value, y: Number(value) });
+    };
+    const updateWidth = (value: string) => {
+      updateBounds({ ...bounds.value, width: Number(value) });
+    };
+    const updateHeight = (value: string) => {
+      updateBounds({ ...bounds.value, height: Number(value) });
+    };
+    const updateBounds = (bounds: Bounds) => {
       report.actions.updateLineItemValues({
-        uid: this.item.uid,
+        uid: item.value.uid,
         values: [
-          { key: 'x1', value: this.isXDirectionPositive ? bounds.x : bounds.x + bounds.width },
-          { key: 'x2', value: this.isXDirectionPositive ? bounds.x + bounds.width : bounds.x },
-          { key: 'y1', value: this.isYDirectionPositive ? bounds.y : bounds.y + bounds.height },
-          { key: 'y2', value: this.isYDirectionPositive ? bounds.y + bounds.height : bounds.y }
+          { key: 'x1', value: isXDirectionPositive.value ? bounds.x : bounds.x + bounds.width },
+          { key: 'x2', value: isXDirectionPositive.value ? bounds.x + bounds.width : bounds.x },
+          { key: 'y1', value: isYDirectionPositive.value ? bounds.y : bounds.y + bounds.height },
+          { key: 'y2', value: isYDirectionPositive.value ? bounds.y + bounds.height : bounds.y }
         ]
       });
-    },
-    updateFollowStretch (value: LineItem['followStretch']) {
-      report.actions.updateLineItem({ uid: this.item.uid, key: 'followStretch', value });
-    },
-    updateAffectBottomMargin (value: boolean) {
-      report.actions.updateLineItem({ uid: this.item.uid, key: 'affectBottomMargin', value });
-    },
-    updateBorderColor (value: string) {
-      report.actions.updateLineItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, borderColor: value } });
-    },
-    updateBorderWidth (value: string) {
-      report.actions.updateLineItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, borderWidth: Number(value) } });
-    },
-    updateBorderStyle (value: LineItem['style']['borderStyle']) {
-      report.actions.updateLineItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, borderStyle: value } });
-    }
+    };
+    const updateFollowStretch = (value: LineItem['followStretch']) => {
+      report.actions.updateLineItem({ uid: item.value.uid, key: 'followStretch', value });
+    };
+    const updateAffectBottomMargin = (value: boolean) => {
+      report.actions.updateLineItem({ uid: item.value.uid, key: 'affectBottomMargin', value });
+    };
+    const updateBorderColor = (value: string) => {
+      report.actions.updateLineItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, borderColor: value } });
+    };
+    const updateBorderWidth = (value: string) => {
+      report.actions.updateLineItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, borderWidth: Number(value) } });
+    };
+    const updateBorderStyle = (value: LineItem['style']['borderStyle']) => {
+      report.actions.updateLineItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, borderStyle: value } });
+    };
+
+    return {
+      bounds,
+      updateId,
+      updateDescription,
+      updateDisplay,
+      updateX,
+      updateY,
+      updateWidth,
+      updateHeight,
+      updateFollowStretch,
+      updateAffectBottomMargin,
+      updateBorderColor,
+      updateBorderWidth,
+      updateBorderStyle
+    };
   }
 });
 </script>

--- a/src/components/property/LineItemProperties.vue
+++ b/src/components/property/LineItemProperties.vue
@@ -96,6 +96,12 @@ export default defineComponent({
   setup (props) {
     const { item } = toRefs(props);
 
+    const isXDirectionPositive = computed((): boolean => {
+      return item.value.x1 < item.value.x2;
+    });
+    const isYDirectionPositive = computed((): boolean => {
+      return item.value.y1 < item.value.y2;
+    });
     const bounds = computed((): Bounds => {
       return {
         x: isXDirectionPositive.value ? item.value.x1 : item.value.x2,
@@ -103,12 +109,6 @@ export default defineComponent({
         width: round(Math.abs(item.value.x1 - item.value.x2)),
         height: round(Math.abs(item.value.y1 - item.value.y2))
       };
-    });
-    const isXDirectionPositive = computed((): boolean => {
-      return item.value.x1 < item.value.x2;
-    });
-    const isYDirectionPositive = computed((): boolean => {
-      return item.value.y1 < item.value.y2;
     });
 
     const updateId = (value: string) => {
@@ -119,6 +119,17 @@ export default defineComponent({
     };
     const updateDisplay = (value: boolean) => {
       report.actions.updateLineItem({ uid: item.value.uid, key: 'display', value });
+    };
+    const updateBounds = (bounds: Bounds) => {
+      report.actions.updateLineItemValues({
+        uid: item.value.uid,
+        values: [
+          { key: 'x1', value: isXDirectionPositive.value ? bounds.x : bounds.x + bounds.width },
+          { key: 'x2', value: isXDirectionPositive.value ? bounds.x + bounds.width : bounds.x },
+          { key: 'y1', value: isYDirectionPositive.value ? bounds.y : bounds.y + bounds.height },
+          { key: 'y2', value: isYDirectionPositive.value ? bounds.y + bounds.height : bounds.y }
+        ]
+      });
     };
     const updateX = (value: string) => {
       updateBounds({ ...bounds.value, x: Number(value) });
@@ -131,17 +142,6 @@ export default defineComponent({
     };
     const updateHeight = (value: string) => {
       updateBounds({ ...bounds.value, height: Number(value) });
-    };
-    const updateBounds = (bounds: Bounds) => {
-      report.actions.updateLineItemValues({
-        uid: item.value.uid,
-        values: [
-          { key: 'x1', value: isXDirectionPositive.value ? bounds.x : bounds.x + bounds.width },
-          { key: 'x2', value: isXDirectionPositive.value ? bounds.x + bounds.width : bounds.x },
-          { key: 'y1', value: isYDirectionPositive.value ? bounds.y : bounds.y + bounds.height },
-          { key: 'y2', value: isYDirectionPositive.value ? bounds.y + bounds.height : bounds.y }
-        ]
-      });
     };
     const updateFollowStretch = (value: LineItem['followStretch']) => {
       report.actions.updateLineItem({ uid: item.value.uid, key: 'followStretch', value });

--- a/src/components/property/PropertyCaption.vue
+++ b/src/components/property/PropertyCaption.vue
@@ -5,10 +5,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 
-export default Vue.extend({
-  name: 'PropertyCaption',
+export default defineComponent({
   props: {
     caption: {
       type: String,

--- a/src/components/property/RectItemProperties.vue
+++ b/src/components/property/RectItemProperties.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import PropertyCaption from './PropertyCaption.vue';
 import AffectBottomMarginProperty from './properties/AffectBottomMarginProperty.vue';
 import CornerRadiusProperty from './properties/CornerRadiusProperty.vue';
@@ -80,8 +80,7 @@ import WidthProperty from './properties/WidthProperty.vue';
 import { report } from '@/store';
 import { RectItem } from '@/types';
 
-export default Vue.extend({
-  name: 'RectItemProperties',
+export default defineComponent({
   components: {
     DisplayProperty,
     IdProperty,
@@ -101,53 +100,72 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<RectItem>,
+      type: Object as () => RectItem,
       required: true
     }
   },
-  methods: {
-    updateId (value: string) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'id', value });
-    },
-    updateDescription (value: string) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'description', value });
-    },
-    updateDisplay (value: boolean) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'display', value });
-    },
-    updateHeight (value: string) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'height', value: Number(value) });
-    },
-    updateWidth (value: string) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'width', value: Number(value) });
-    },
-    updateX (value: string) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'x', value: Number(value) });
-    },
-    updateY (value: string) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'y', value: Number(value) });
-    },
-    updateFollowStretch (value: RectItem['followStretch']) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'followStretch', value });
-    },
-    updateAffectBottomMargin (value: boolean) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'affectBottomMargin', value });
-    },
-    updateFillColor (value: string) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, fillColor: value } });
-    },
-    updateBorderColor (value: string) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, borderColor: value } });
-    },
-    updateBorderWidth (value: string) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, borderWidth: Number(value) } });
-    },
-    updateBorderStyle (value: RectItem['style']['borderStyle']) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, borderStyle: value } });
-    },
-    updateBorderRadius (value: string) {
-      report.actions.updateRectItem({ uid: this.item.uid, key: 'borderRadius', value: Number(value) });
-    }
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const updateId = (value: string) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'id', value });
+    };
+    const updateDescription = (value: string) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'description', value });
+    };
+    const updateDisplay = (value: boolean) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'display', value });
+    };
+    const updateHeight = (value: string) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'height', value: Number(value) });
+    };
+    const updateWidth = (value: string) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'width', value: Number(value) });
+    };
+    const updateX = (value: string) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'x', value: Number(value) });
+    };
+    const updateY = (value: string) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'y', value: Number(value) });
+    };
+    const updateFollowStretch = (value: RectItem['followStretch']) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'followStretch', value });
+    };
+    const updateAffectBottomMargin = (value: boolean) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'affectBottomMargin', value });
+    };
+    const updateFillColor = (value: string) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, fillColor: value } });
+    };
+    const updateBorderColor = (value: string) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, borderColor: value } });
+    };
+    const updateBorderWidth = (value: string) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, borderWidth: Number(value) } });
+    };
+    const updateBorderStyle = (value: RectItem['style']['borderStyle']) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, borderStyle: value } });
+    };
+    const updateBorderRadius = (value: string) => {
+      report.actions.updateRectItem({ uid: item.value.uid, key: 'borderRadius', value: Number(value) });
+    };
+
+    return {
+      updateId,
+      updateDescription,
+      updateDisplay,
+      updateHeight,
+      updateWidth,
+      updateX,
+      updateY,
+      updateFollowStretch,
+      updateAffectBottomMargin,
+      updateFillColor,
+      updateBorderColor,
+      updateBorderWidth,
+      updateBorderStyle,
+      updateBorderRadius
+    };
   }
 });
 </script>

--- a/src/components/property/SectionProperties.vue
+++ b/src/components/property/SectionProperties.vue
@@ -16,14 +16,13 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import DetailSectionProperties from './DetailSectionProperties.vue';
 import FooterSectionProperties from './FooterSectionProperties.vue';
 import HeaderSectionProperties from './HeaderSectionProperties.vue';
 import { AnySection } from '@/types';
 
-export default Vue.extend({
-  name: 'SectionProperties',
+export default defineComponent({
   components: {
     HeaderSectionProperties,
     DetailSectionProperties,
@@ -31,22 +30,28 @@ export default Vue.extend({
   },
   props: {
     section: {
-      type: Object as PropType<AnySection>,
+      type: Object as () => AnySection,
       required: true
     }
   },
-  computed: {
-    isHeaderSection (): boolean {
-      return this.section.type === 'header';
-    },
+  setup (props) {
+    const { section } = toRefs(props);
 
-    isDetailSection (): boolean {
-      return this.section.type === 'detail';
-    },
+    const isHeaderSection = computed((): boolean => {
+      return section.value.type === 'header';
+    });
+    const isDetailSection = computed((): boolean => {
+      return section.value.type === 'detail';
+    });
+    const isFooterSection = computed((): boolean => {
+      return section.value.type === 'footer';
+    });
 
-    isFooterSection (): boolean {
-      return this.section.type === 'footer';
-    }
+    return {
+      isHeaderSection,
+      isDetailSection,
+      isFooterSection
+    };
   }
 });
 </script>

--- a/src/components/property/StackViewItemProperties.vue
+++ b/src/components/property/StackViewItemProperties.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import PropertyCaption from './PropertyCaption.vue';
 import AffectBottomMarginProperty from './properties/AffectBottomMarginProperty.vue';
 import DescriptionProperty from './properties/DescriptionProperty.vue';
@@ -51,8 +51,7 @@ import WidthProperty from './properties/WidthProperty.vue';
 import { report } from '@/store';
 import { StackViewItem, Item } from '@/types';
 
-export default Vue.extend({
-  name: 'StackViewItemProperties',
+export default defineComponent({
   components: {
     DisplayProperty,
     IdProperty,
@@ -66,35 +65,48 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<StackViewItem>,
+      type: Object as () => StackViewItem,
       required: true
     }
   },
-  methods: {
-    updateWidth (value: boolean) {
-      report.actions.updateStackViewItem({ uid: this.item.uid, key: 'width', value: Number(value) });
-    },
-    updateX (value: boolean) {
-      report.actions.updateStackViewItem({ uid: this.item.uid, key: 'x', value: Number(value) });
-    },
-    updateY (value: boolean) {
-      report.actions.updateStackViewItem({ uid: this.item.uid, key: 'y', value: Number(value) });
-    },
-    updateDisplay (value: boolean) {
-      report.actions.updateStackViewItem({ uid: this.item.uid, key: 'display', value });
-    },
-    updateFollowStretch (value: Item['followStretch']) {
-      report.actions.updateStackViewItem({ uid: this.item.uid, key: 'followStretch', value });
-    },
-    updateAffectBottomMargin (value: boolean) {
-      report.actions.updateStackViewItem({ uid: this.item.uid, key: 'affectBottomMargin', value });
-    },
-    updateId (value: string) {
-      report.actions.updateStackViewItem({ uid: this.item.uid, key: 'id', value });
-    },
-    updateDescription (value: string) {
-      report.actions.updateStackViewItem({ uid: this.item.uid, key: 'description', value });
-    }
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const updateWidth = (value: boolean) => {
+      report.actions.updateStackViewItem({ uid: item.value.uid, key: 'width', value: Number(value) });
+    };
+    const updateX = (value: boolean) => {
+      report.actions.updateStackViewItem({ uid: item.value.uid, key: 'x', value: Number(value) });
+    };
+    const updateY = (value: boolean) => {
+      report.actions.updateStackViewItem({ uid: item.value.uid, key: 'y', value: Number(value) });
+    };
+    const updateDisplay = (value: boolean) => {
+      report.actions.updateStackViewItem({ uid: item.value.uid, key: 'display', value });
+    };
+    const updateFollowStretch = (value: Item['followStretch']) => {
+      report.actions.updateStackViewItem({ uid: item.value.uid, key: 'followStretch', value });
+    };
+    const updateAffectBottomMargin = (value: boolean) => {
+      report.actions.updateStackViewItem({ uid: item.value.uid, key: 'affectBottomMargin', value });
+    };
+    const updateId = (value: string) => {
+      report.actions.updateStackViewItem({ uid: item.value.uid, key: 'id', value });
+    };
+    const updateDescription = (value: string) => {
+      report.actions.updateStackViewItem({ uid: item.value.uid, key: 'description', value });
+    };
+
+    return {
+      updateWidth,
+      updateX,
+      updateY,
+      updateDisplay,
+      updateFollowStretch,
+      updateAffectBottomMargin,
+      updateId,
+      updateDescription
+    };
   }
 });
 </script>

--- a/src/components/property/StackViewRowProperties.vue
+++ b/src/components/property/StackViewRowProperties.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import PropertyCaption from './PropertyCaption.vue';
 import AutoStretchProperty from './properties//AutoStretchProperty.vue';
 import HeightProperty from './properties//HeightProperty.vue';
@@ -30,8 +30,7 @@ import IdProperty from './properties/IdProperty.vue';
 import { report } from '@/store';
 import { StackViewRow } from '@/types';
 
-export default Vue.extend({
-  name: 'StackViewRowProperties',
+export default defineComponent({
   components: {
     DisplayProperty,
     IdProperty,
@@ -41,23 +40,32 @@ export default Vue.extend({
   },
   props: {
     row: {
-      type: Object as PropType<StackViewRow>,
+      type: Object as () => StackViewRow,
       required: true
     }
   },
-  methods: {
-    updateId (value: string) {
-      report.actions.updateStackViewRow({ uid: this.row.uid, key: 'id', value });
-    },
-    updateDisplay (value: boolean) {
-      report.actions.updateStackViewRow({ uid: this.row.uid, key: 'display', value });
-    },
-    updateHeight (value: string) {
-      report.actions.updateStackViewRow({ uid: this.row.uid, key: 'height', value: Number(value) });
-    },
-    updateAutoStretch (value: boolean) {
-      report.actions.updateStackViewRow({ uid: this.row.uid, key: 'autoStretch', value });
-    }
+  setup (props) {
+    const { row } = toRefs(props);
+
+    const updateId = (value: string) => {
+      report.actions.updateStackViewRow({ uid: row.value.uid, key: 'id', value });
+    };
+    const updateDisplay = (value: boolean) => {
+      report.actions.updateStackViewRow({ uid: row.value.uid, key: 'display', value });
+    };
+    const updateHeight = (value: string) => {
+      report.actions.updateStackViewRow({ uid: row.value.uid, key: 'height', value: Number(value) });
+    };
+    const updateAutoStretch = (value: boolean) => {
+      report.actions.updateStackViewRow({ uid: row.value.uid, key: 'autoStretch', value });
+    };
+
+    return {
+      updateId,
+      updateDisplay,
+      updateHeight,
+      updateAutoStretch
+    };
   }
 });
 </script>

--- a/src/components/property/TextBlockItemProperties.vue
+++ b/src/components/property/TextBlockItemProperties.vue
@@ -105,7 +105,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import PropertyCaption from './PropertyCaption.vue';
 import AffectBottomMarginProperty from './properties/AffectBottomMarginProperty.vue';
 import BasicFormatProperty from './properties/BasicFormatProperty.vue';
@@ -135,8 +135,7 @@ import WordWrapProperty from './properties/WordWrapProperty.vue';
 import { report } from '@/store';
 import { TextBlockItem, BuiltinFontFamily, ItemTextStyle, TextOverflowStyle, TextWordWrapStyle } from '@/types';
 
-export default Vue.extend({
-  name: 'TextBlockItemProperties',
+export default defineComponent({
   components: {
     DisplayProperty,
     IdProperty,
@@ -167,102 +166,135 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<TextBlockItem>,
+      type: Object as () => TextBlockItem,
       required: true
     }
   },
-  computed: {
-    isBold () {
-      return this.item.style.fontStyle.includes('bold');
-    },
-    isItalic () {
-      return this.item.style.fontStyle.includes('italic');
-    },
-    isUnderline () {
-      return this.item.style.fontStyle.includes('underline');
-    },
-    isLinethrough () {
-      return this.item.style.fontStyle.includes('linethrough');
-    }
-  },
-  methods: {
-    updateId (value: string) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'id', value });
-    },
-    updateDescription (value: string) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'description', value });
-    },
-    updateDisplay (value: boolean) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'display', value });
-    },
-    updateHeight (value: string) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'height', value: Number(value) });
-    },
-    updateWidth (value: string) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'width', value: Number(value) });
-    },
-    updateX (value: string) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'x', value: Number(value) });
-    },
-    updateY (value: string) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'y', value: Number(value) });
-    },
-    updateFollowStretch (value: TextBlockItem['followStretch']) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'followStretch', value });
-    },
-    updateAffectBottomMargin (value: boolean) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'affectBottomMargin', value });
-    },
-    updateColor (value: string) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, color: value } });
-    },
-    updateFontSize (value: string) {
-      report.actions.updateTextFontAndLineSize({ uid: this.item.uid, fontSize: Number(value), lineHeightRatio: this.item.style.lineHeightRatio });
-    },
-    updateFontFamily (value: BuiltinFontFamily) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, fontFamily: [value] } });
-    },
-    updateTextAlign (value: ItemTextStyle['textAlign']) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, textAlign: value } });
-    },
-    updateVerticalAlign (value: ItemTextStyle['verticalAlign']) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, verticalAlign: value } });
-    },
-    updateLineHeightRatio (value: string) {
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const isBold = computed(() => {
+      return item.value.style.fontStyle.includes('bold');
+    });
+    const isItalic = computed(() => {
+      return item.value.style.fontStyle.includes('italic');
+    });
+    const isUnderline = computed(() => {
+      return item.value.style.fontStyle.includes('underline');
+    });
+    const isLinethrough = computed(() => {
+      return item.value.style.fontStyle.includes('linethrough');
+    });
+
+    const updateId = (value: string) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'id', value });
+    };
+    const updateDescription = (value: string) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'description', value });
+    };
+    const updateDisplay = (value: boolean) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'display', value });
+    };
+    const updateHeight = (value: string) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'height', value: Number(value) });
+    };
+    const updateWidth = (value: string) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'width', value: Number(value) });
+    };
+    const updateX = (value: string) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'x', value: Number(value) });
+    };
+    const updateY = (value: string) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'y', value: Number(value) });
+    };
+    const updateFollowStretch = (value: TextBlockItem['followStretch']) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'followStretch', value });
+    };
+    const updateAffectBottomMargin = (value: boolean) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'affectBottomMargin', value });
+    };
+    const updateColor = (value: string) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, color: value } });
+    };
+    const updateFontSize = (value: string) => {
+      report.actions.updateTextFontAndLineSize({ uid: item.value.uid, fontSize: Number(value), lineHeightRatio: item.value.style.lineHeightRatio });
+    };
+    const updateFontFamily = (value: BuiltinFontFamily) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, fontFamily: [value] } });
+    };
+    const updateTextAlign = (value: ItemTextStyle['textAlign']) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, textAlign: value } });
+    };
+    const updateVerticalAlign = (value: ItemTextStyle['verticalAlign']) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, verticalAlign: value } });
+    };
+    const updateLineHeightRatio = (value: string) => {
       const lineHeightRatio = value !== '' ? Number(value) : '';
-      report.actions.updateTextFontAndLineSize({ uid: this.item.uid, fontSize: this.item.style.fontSize, lineHeightRatio });
-    },
-    updateLetterSpacing (value: string) {
+      report.actions.updateTextFontAndLineSize({ uid: item.value.uid, fontSize: item.value.style.fontSize, lineHeightRatio });
+    };
+    const updateLetterSpacing = (value: string) => {
       const letterSpacing = value !== '' ? Number(value) : '';
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, letterSpacing } });
-    },
-    updateBasicFormat (value: string) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'format', value: { ...this.item.format, base: value } });
-    },
-    updateDefaultValue (value: string) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'value', value });
-    },
-    updateOverflow (value: TextOverflowStyle) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, overflow: value } });
-    },
-    updateWordWrap (value: TextWordWrapStyle) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, wordWrap: value } });
-    },
-    updateMultipleLine (value: boolean) {
-      report.actions.updateTextBlockItem({ uid: this.item.uid, key: 'multipleLine', value });
-    },
-    updateBold (value: boolean) {
-      report.actions.updateTextBlockItemWith(this.item.uid, item => { item.bold = value; });
-    },
-    updateItalic (value: boolean) {
-      report.actions.updateTextBlockItemWith(this.item.uid, item => { item.italic = value; });
-    },
-    updateUnderline (value: boolean) {
-      report.actions.updateTextBlockItemWith(this.item.uid, item => { item.underline = value; });
-    },
-    updateLinethrough (value: boolean) {
-      report.actions.updateTextBlockItemWith(this.item.uid, item => { item.linethrough = value; });
-    }
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, letterSpacing } });
+    };
+    const updateBasicFormat = (value: string) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'format', value: { ...item.value.format, base: value } });
+    };
+    const updateDefaultValue = (value: string) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'value', value });
+    };
+    const updateOverflow = (value: TextOverflowStyle) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, overflow: value } });
+    };
+    const updateWordWrap = (value: TextWordWrapStyle) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, wordWrap: value } });
+    };
+    const updateMultipleLine = (value: boolean) => {
+      report.actions.updateTextBlockItem({ uid: item.value.uid, key: 'multipleLine', value });
+    };
+    const updateBold = (value: boolean) => {
+      report.actions.updateTextBlockItemWith(item.value.uid, item => { item.bold = value; });
+    };
+    const updateItalic = (value: boolean) => {
+      report.actions.updateTextBlockItemWith(item.value.uid, item => { item.italic = value; });
+    };
+    const updateUnderline = (value: boolean) => {
+      report.actions.updateTextBlockItemWith(item.value.uid, item => { item.underline = value; });
+    };
+    const updateLinethrough = (value: boolean) => {
+      report.actions.updateTextBlockItemWith(item.value.uid, item => { item.linethrough = value; });
+    };
+
+    return {
+      isBold,
+      isItalic,
+      isUnderline,
+      isLinethrough,
+      updateId,
+      updateDescription,
+      updateDisplay,
+      updateHeight,
+      updateWidth,
+      updateX,
+      updateY,
+      updateFollowStretch,
+      updateAffectBottomMargin,
+      updateColor,
+      updateFontSize,
+      updateFontFamily,
+      updateTextAlign,
+      updateVerticalAlign,
+      updateLineHeightRatio,
+      updateLetterSpacing,
+      updateBasicFormat,
+      updateDefaultValue,
+      updateOverflow,
+      updateWordWrap,
+      updateMultipleLine,
+      updateBold,
+      updateItalic,
+      updateUnderline,
+      updateLinethrough
+    };
   }
 });
 </script>

--- a/src/components/property/TextItemProperties.vue
+++ b/src/components/property/TextItemProperties.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import PropertyCaption from './PropertyCaption.vue';
 import AffectBottomMarginProperty from './properties/AffectBottomMarginProperty.vue';
 import DescriptionProperty from './properties/DescriptionProperty.vue';
@@ -115,8 +115,7 @@ import WidthProperty from './properties/WidthProperty.vue';
 import { report } from '@/store';
 import { TextItem, BuiltinFontFamily, ItemTextStyle } from '@/types';
 
-export default Vue.extend({
-  name: 'TextItemProperties',
+export default defineComponent({
   components: {
     DisplayProperty,
     IdProperty,
@@ -143,102 +142,132 @@ export default Vue.extend({
   },
   props: {
     item: {
-      type: Object as PropType<TextItem>,
+      type: Object as () => TextItem,
       required: true
     }
   },
-  computed: {
-    text () {
-      return this.item.texts.join('\n');
-    },
-    isBold () {
-      return this.item.style.fontStyle.includes('bold');
-    },
-    isItalic () {
-      return this.item.style.fontStyle.includes('italic');
-    },
-    isUnderline () {
-      return this.item.style.fontStyle.includes('underline');
-    },
-    isLinethrough () {
-      return this.item.style.fontStyle.includes('linethrough');
-    }
-  },
-  methods: {
-    updateId (value: string) {
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'id', value });
-    },
-    updateDescription (value: string) {
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'description', value });
-    },
-    updateDisplay (value: boolean) {
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'display', value });
-    },
-    updateHeight (value: string) {
-      report.actions.updateTextItemWith(this.item.uid, item => {
+  setup (props) {
+    const { item } = toRefs(props);
+
+    const text = computed(() => {
+      return item.value.texts.join('\n');
+    });
+    const isBold = computed(() => {
+      return item.value.style.fontStyle.includes('bold');
+    });
+    const isItalic = computed(() => {
+      return item.value.style.fontStyle.includes('italic');
+    });
+    const isUnderline = computed(() => {
+      return item.value.style.fontStyle.includes('underline');
+    });
+    const isLinethrough = computed(() => {
+      return item.value.style.fontStyle.includes('linethrough');
+    });
+
+    const updateId = (value: string) => {
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'id', value });
+    };
+    const updateDescription = (value: string) => {
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'description', value });
+    };
+    const updateDisplay = (value: boolean) => {
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'display', value });
+    };
+    const updateHeight = (value: string) => {
+      report.actions.updateTextItemWith(item.value.uid, item => {
         item.height = Number(value);
       });
-    },
-    updateWidth (value: string) {
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'width', value: Number(value) });
-    },
-    updateX (value: string) {
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'x', value: Number(value) });
-    },
-    updateY (value: string) {
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'y', value: Number(value) });
-    },
-    updateFollowStretch (value: TextItem['followStretch']) {
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'followStretch', value });
-    },
-    updateAffectBottomMargin (value: boolean) {
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'affectBottomMargin', value });
-    },
-    updateTexts (value: string) {
-      report.actions.updateTextItemWith(this.item.uid, item => {
+    };
+    const updateWidth = (value: string) => {
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'width', value: Number(value) });
+    };
+    const updateX = (value: string) => {
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'x', value: Number(value) });
+    };
+    const updateY = (value: string) => {
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'y', value: Number(value) });
+    };
+    const updateFollowStretch = (value: TextItem['followStretch']) => {
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'followStretch', value });
+    };
+    const updateAffectBottomMargin = (value: boolean) => {
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'affectBottomMargin', value });
+    };
+    const updateTexts = (value: string) => {
+      report.actions.updateTextItemWith(item.value.uid, item => {
         item.texts = value.split('\n');
       });
-    },
-    updateColor (value: string) {
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, color: value } });
-    },
-    updateFontSize (value: string) {
-      report.actions.updateTextItemWith(this.item.uid, item => {
+    };
+    const updateColor = (value: string) => {
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, color: value } });
+    };
+    const updateFontSize = (value: string) => {
+      report.actions.updateTextItemWith(item.value.uid, item => {
         item.fontSize = Number(value);
       });
-    },
-    updateFontFamily (value: BuiltinFontFamily) {
-      report.actions.updateTextItemWith(this.item.uid, item => {
+    };
+    const updateFontFamily = (value: BuiltinFontFamily) => {
+      report.actions.updateTextItemWith(item.value.uid, item => {
         item.fontFamily = value;
       });
-    },
-    updateTextAlign (value: ItemTextStyle['textAlign']) {
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, textAlign: value } });
-    },
-    updateVerticalAlign (value: ItemTextStyle['verticalAlign']) {
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, verticalAlign: value } });
-    },
-    updateLineHeightRatio (value: string) {
-      report.actions.updateTextItemWith(this.item.uid, item => {
+    };
+    const updateTextAlign = (value: ItemTextStyle['textAlign']) => {
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, textAlign: value } });
+    };
+    const updateVerticalAlign = (value: ItemTextStyle['verticalAlign']) => {
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, verticalAlign: value } });
+    };
+    const updateLineHeightRatio = (value: string) => {
+      report.actions.updateTextItemWith(item.value.uid, item => {
         item.lineHeightRatio = value !== '' ? Number(value) : '';
       });
-    },
-    updateLetterSpacing (value: string) {
+    };
+    const updateLetterSpacing = (value: string) => {
       const letterSpacing = value !== '' ? Number(value) : '';
-      report.actions.updateTextItem({ uid: this.item.uid, key: 'style', value: { ...this.item.style, letterSpacing } });
-    },
-    updateBold (value: boolean) {
-      report.actions.updateTextItemWith(this.item.uid, item => { item.bold = value; });
-    },
-    updateItalic (value: boolean) {
-      report.actions.updateTextItemWith(this.item.uid, item => { item.italic = value; });
-    },
-    updateUnderline (value: boolean) {
-      report.actions.updateTextItemWith(this.item.uid, item => { item.underline = value; });
-    },
-    updateLinethrough (value: boolean) {
-      report.actions.updateTextItemWith(this.item.uid, item => { item.linethrough = value; });
-    }
+      report.actions.updateTextItem({ uid: item.value.uid, key: 'style', value: { ...item.value.style, letterSpacing } });
+    };
+    const updateBold = (value: boolean) => {
+      report.actions.updateTextItemWith(item.value.uid, item => { item.bold = value; });
+    };
+    const updateItalic = (value: boolean) => {
+      report.actions.updateTextItemWith(item.value.uid, item => { item.italic = value; });
+    };
+    const updateUnderline = (value: boolean) => {
+      report.actions.updateTextItemWith(item.value.uid, item => { item.underline = value; });
+    };
+    const updateLinethrough = (value: boolean) => {
+      report.actions.updateTextItemWith(item.value.uid, item => { item.linethrough = value; });
+    };
+
+    return {
+      text,
+      isBold,
+      isItalic,
+      isUnderline,
+      isLinethrough,
+      updateId,
+      updateDescription,
+      updateDisplay,
+      updateHeight,
+      updateWidth,
+      updateX,
+      updateY,
+      updateFollowStretch,
+      updateAffectBottomMargin,
+      updateTexts,
+      updateColor,
+      updateFontSize,
+      updateFontFamily,
+      updateTextAlign,
+      updateVerticalAlign,
+      updateLineHeightRatio,
+      updateLetterSpacing,
+      updateBold,
+      updateItalic,
+      updateUnderline,
+      updateLinethrough
+    };
   }
 });
 </script>

--- a/src/components/property/properties/AffectBottomMarginProperty.vue
+++ b/src/components/property/properties/AffectBottomMarginProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import CheckProperty from './base/CheckProperty.vue';
 
-export default Vue.extend({
-  name: 'AffectBottomMargin',
+export default defineComponent({
   components: {
     CheckProperty
   },
@@ -21,10 +20,16 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update () {
-      this.$emit('change', !this.value);
-    }
+  setup (props, { emit }) {
+    const { value } = toRefs(props);
+
+    const update = () => {
+      emit('change', !value.value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/AutoStretchProperty.vue
+++ b/src/components/property/properties/AutoStretchProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import CheckProperty from './base/CheckProperty.vue';
 
-export default Vue.extend({
-  name: 'AutoStretchProperty',
+export default defineComponent({
   components: {
     CheckProperty
   },
@@ -21,10 +20,16 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update () {
-      this.$emit('change', !this.value);
-    }
+  setup (props, { emit }) {
+    const { value } = toRefs(props);
+
+    const update = () => {
+      emit('change', !value.value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/BasicFormatProperty.vue
+++ b/src/components/property/properties/BasicFormatProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from './base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'BasicFormatProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/CornerRadiusProperty.vue
+++ b/src/components/property/properties/CornerRadiusProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from '@/components/property/properties/base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'CornerRadiusProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/DefaultTextProperty.vue
+++ b/src/components/property/properties/DefaultTextProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from './base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'DefaultTextProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       default: ''
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/DescriptionProperty.vue
+++ b/src/components/property/properties/DescriptionProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from './base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'DescriptionProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       default: ''
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/DisplayProperty.vue
+++ b/src/components/property/properties/DisplayProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import CheckProperty from './base/CheckProperty.vue';
 
-export default Vue.extend({
-  name: 'DisplayProperty',
+export default defineComponent({
   components: {
     CheckProperty
   },
@@ -21,10 +20,16 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update () {
-      this.$emit('change', !this.value);
-    }
+  setup (props, { emit }) {
+    const { value } = toRefs(props);
+
+    const update = () => {
+      emit('change', !value.value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/EveryPageProperty.vue
+++ b/src/components/property/properties/EveryPageProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import CheckProperty from './base/CheckProperty.vue';
 
-export default Vue.extend({
-  name: 'EveryPage',
+export default defineComponent({
   components: {
     CheckProperty
   },
@@ -21,10 +20,16 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update () {
-      this.$emit('change', !this.value);
-    }
+  setup (props, { emit }) {
+    const { value } = toRefs(props);
+
+    const update = () => {
+      emit('change', !value.value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/FillColorProperty.vue
+++ b/src/components/property/properties/FillColorProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from '@/components/property/properties/base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'FillColorProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/FixedBottomProperty.vue
+++ b/src/components/property/properties/FixedBottomProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import CheckProperty from './base/CheckProperty.vue';
 
-export default Vue.extend({
-  name: 'FixedBottomProperty',
+export default defineComponent({
   components: {
     CheckProperty
   },
@@ -21,10 +20,16 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update () {
-      this.$emit('change', !this.value);
-    }
+  setup (props, { emit }) {
+    const { value } = toRefs(props);
+
+    const update = () => {
+      emit('change', !value.value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/FollowStretchProperty.vue
+++ b/src/components/property/properties/FollowStretchProperty.vue
@@ -8,18 +8,17 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import SelectProperty, { Option } from './base/SelectProperty.vue';
 import { Item } from '@/types';
 
-export default Vue.extend({
-  name: 'FollowStretchProperty',
+export default defineComponent({
   components: {
     SelectProperty
   },
   props: {
     value: {
-      type: String as PropType<Item['followStretch']>,
+      type: String as () => Item['followStretch'],
       required: true
     },
     ignoreHeight: {
@@ -27,20 +26,26 @@ export default Vue.extend({
       default: false
     }
   },
-  computed: {
-    options (): Option<Item['followStretch']>[] {
+  setup (props, { emit }) {
+    const { ignoreHeight } = toRefs(props);
+
+    const options = computed((): Option<Item['followStretch']>[] => {
       const options: Option<Item['followStretch']>[] = [
         { label: 'none', value: 'none' },
         { label: 'y', value: 'y' }
       ];
 
-      return this.ignoreHeight ? options : [...options, { label: 'height', value: 'height' }];
-    }
-  },
-  methods: {
-    update (value: Item['followStretch']) {
-      this.$emit('change', value);
-    }
+      return ignoreHeight.value ? options : [...options, { label: 'height', value: 'height' }];
+    });
+
+    const update = (value: Item['followStretch']) => {
+      emit('change', value);
+    };
+
+    return {
+      options,
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/FontColorProperty.vue
+++ b/src/components/property/properties/FontColorProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from '@/components/property/properties/base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'FontColorProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/FontFamilyProperty.vue
+++ b/src/components/property/properties/FontFamilyProperty.vue
@@ -8,23 +8,22 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import SelectProperty, { Option } from './base/SelectProperty.vue';
 import { BuiltinFontFamily } from '@/types';
 
-export default Vue.extend({
-  name: 'FontFamilyProperty',
+export default defineComponent({
   components: {
     SelectProperty
   },
   props: {
     value: {
-      type: String as PropType<BuiltinFontFamily>,
+      type: String as () => BuiltinFontFamily,
       required: true
     }
   },
-  computed: {
-    options (): Option<BuiltinFontFamily>[] {
+  setup (_, { emit }) {
+    const options = computed((): Option<BuiltinFontFamily>[] => {
       return [
         { label: 'Helvetica', value: 'Helvetica' },
         { label: 'Courier New', value: 'Courier New' },
@@ -34,12 +33,16 @@ export default Vue.extend({
         { label: 'IPA ゴシック', value: 'IPAGothic' },
         { label: 'IPA Pゴシック', value: 'IPAPGothic' }
       ];
-    }
-  },
-  methods: {
-    update (value: BuiltinFontFamily) {
-      this.$emit('change', value);
-    }
+    });
+
+    const update = (value: BuiltinFontFamily) => {
+      emit('change', value);
+    };
+
+    return {
+      options,
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/FontSizeProperty.vue
+++ b/src/components/property/properties/FontSizeProperty.vue
@@ -7,25 +7,28 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import { ItemTextStyle } from '../../../types';
 import TextProperty from '@/components/property/properties/base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'FontSizeProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
   props: {
     value: {
-      type: Number as PropType<ItemTextStyle['fontSize']>,
+      type: Number as () => ItemTextStyle['fontSize'],
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/FontStyleBoldProperty.vue
+++ b/src/components/property/properties/FontStyleBoldProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import CheckProperty from './base/CheckProperty.vue';
 
-export default Vue.extend({
-  name: 'FontStyleBoldProperty',
+export default defineComponent({
   components: {
     CheckProperty
   },
@@ -21,10 +20,16 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update () {
-      this.$emit('change', !this.value);
-    }
+  setup (props, { emit }) {
+    const { value } = toRefs(props);
+
+    const update = () => {
+      emit('change', !value.value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/FontStyleItalicProperty.vue
+++ b/src/components/property/properties/FontStyleItalicProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import CheckProperty from './base/CheckProperty.vue';
 
-export default Vue.extend({
-  name: 'FontStyleItalicProperty',
+export default defineComponent({
   components: {
     CheckProperty
   },
@@ -21,10 +20,16 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update () {
-      this.$emit('change', !this.value);
-    }
+  setup (props, { emit }) {
+    const { value } = toRefs(props);
+
+    const update = () => {
+      emit('change', !value.value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/FontStyleLinethroughProperty.vue
+++ b/src/components/property/properties/FontStyleLinethroughProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import CheckProperty from './base/CheckProperty.vue';
 
-export default Vue.extend({
-  name: 'FontStyleUnderlineProperty',
+export default defineComponent({
   components: {
     CheckProperty
   },
@@ -21,10 +20,16 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update () {
-      this.$emit('change', !this.value);
-    }
+  setup (props, { emit }) {
+    const { value } = toRefs(props);
+
+    const update = () => {
+      emit('change', !value.value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/FontStyleUnderlineProperty.vue
+++ b/src/components/property/properties/FontStyleUnderlineProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import CheckProperty from './base/CheckProperty.vue';
 
-export default Vue.extend({
-  name: 'FontStyleUnderlineProperty',
+export default defineComponent({
   components: {
     CheckProperty
   },
@@ -21,10 +20,16 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update () {
-      this.$emit('change', !this.value);
-    }
+  setup (props, { emit }) {
+    const { value } = toRefs(props);
+
+    const update = () => {
+      emit('change', !value.value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/HeightProperty.vue
+++ b/src/components/property/properties/HeightProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from './base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'HeightProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', Number(value));
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', Number(value));
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/HorizontalAlignProperty.vue
+++ b/src/components/property/properties/HorizontalAlignProperty.vue
@@ -8,34 +8,37 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import SelectProperty, { Option } from './base/SelectProperty.vue';
 import { HorizontalAlign } from '@/types';
 
-export default Vue.extend({
-  name: 'HorizontalAlignProperty',
+export default defineComponent({
   components: {
     SelectProperty
   },
   props: {
     value: {
-      type: String as PropType<HorizontalAlign>,
+      type: String as () => HorizontalAlign,
       required: true
     }
   },
-  computed: {
-    options (): Option<HorizontalAlign>[] {
+  setup (_, { emit }) {
+    const options = computed((): Option<HorizontalAlign>[] => {
       return [
         { label: this.$tc('label.align.horizontal.left'), value: 'left' },
         { label: this.$tc('label.align.horizontal.center'), value: 'center' },
         { label: this.$tc('label.align.horizontal.right'), value: 'right' }
       ];
-    }
-  },
-  methods: {
-    update (value: HorizontalAlign) {
-      this.$emit('change', value);
-    }
+    });
+
+    const update = (value: HorizontalAlign) => {
+      emit('change', value);
+    };
+
+    return {
+      options,
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/HorizontalAlignProperty.vue
+++ b/src/components/property/properties/HorizontalAlignProperty.vue
@@ -10,6 +10,7 @@
 <script lang="ts">
 import { computed, defineComponent } from '@vue/composition-api';
 import SelectProperty, { Option } from './base/SelectProperty.vue';
+import { useI18n } from '@/composables/useI18n';
 import { HorizontalAlign } from '@/types';
 
 export default defineComponent({
@@ -23,11 +24,13 @@ export default defineComponent({
     }
   },
   setup (_, { emit }) {
+    const { i18n } = useI18n();
+
     const options = computed((): Option<HorizontalAlign>[] => {
       return [
-        { label: this.$tc('label.align.horizontal.left'), value: 'left' },
-        { label: this.$tc('label.align.horizontal.center'), value: 'center' },
-        { label: this.$tc('label.align.horizontal.right'), value: 'right' }
+        { label: i18n.value.tc('label.align.horizontal.left'), value: 'left' },
+        { label: i18n.value.tc('label.align.horizontal.center'), value: 'center' },
+        { label: i18n.value.tc('label.align.horizontal.right'), value: 'right' }
       ];
     });
 

--- a/src/components/property/properties/IdProperty.vue
+++ b/src/components/property/properties/IdProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from './base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'IdProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/KerningProperty.vue
+++ b/src/components/property/properties/KerningProperty.vue
@@ -8,11 +8,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from './base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'KerningProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -22,10 +21,14 @@ export default Vue.extend({
       default: ''
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/LeftProperty.vue
+++ b/src/components/property/properties/LeftProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from '@/components/property/properties/base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'LeftProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/LineHeightRatioProperty.vue
+++ b/src/components/property/properties/LineHeightRatioProperty.vue
@@ -8,11 +8,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from './base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'LineHeightRatioProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -22,10 +21,14 @@ export default Vue.extend({
       default: ''
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/MultipleLineProperty.vue
+++ b/src/components/property/properties/MultipleLineProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 import CheckProperty from './base/CheckProperty.vue';
 
-export default Vue.extend({
-  name: 'MultipleLineProperty',
+export default defineComponent({
   components: {
     CheckProperty
   },
@@ -21,10 +20,16 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update () {
-      this.$emit('change', !this.value);
-    }
+  setup (props, { emit }) {
+    const { value } = toRefs(props);
+
+    const update = () => {
+      emit('change', !value.value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/OverflowProperty.vue
+++ b/src/components/property/properties/OverflowProperty.vue
@@ -8,34 +8,37 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import SelectProperty, { Option } from './base/SelectProperty.vue';
 import { TextOverflowStyle } from '@/types';
 
-export default Vue.extend({
-  name: 'OverflowProperty',
+export default defineComponent({
   components: {
     SelectProperty
   },
   props: {
     value: {
-      type: String as PropType<TextOverflowStyle>,
+      type: String as () => TextOverflowStyle,
       required: true
     }
   },
-  computed: {
-    options (): Option<TextOverflowStyle>[] {
+  setup (_, { emit }) {
+    const options = computed((): Option<TextOverflowStyle>[] => {
       return [
         { label: this.$tc('label.text.overflow.truncate'), value: 'truncate' },
         { label: this.$tc('label.text.overflow.fit'), value: 'fit' },
         { label: this.$tc('label.text.overflow.expand'), value: 'expand' }
       ];
-    }
-  },
-  methods: {
-    update (value: TextOverflowStyle) {
-      this.$emit('change', value);
-    }
+    });
+
+    const update = (value: TextOverflowStyle) => {
+      emit('change', value);
+    };
+
+    return {
+      options,
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/OverflowProperty.vue
+++ b/src/components/property/properties/OverflowProperty.vue
@@ -10,6 +10,7 @@
 <script lang="ts">
 import { computed, defineComponent } from '@vue/composition-api';
 import SelectProperty, { Option } from './base/SelectProperty.vue';
+import { useI18n } from '@/composables/useI18n';
 import { TextOverflowStyle } from '@/types';
 
 export default defineComponent({
@@ -23,11 +24,13 @@ export default defineComponent({
     }
   },
   setup (_, { emit }) {
+    const { i18n } = useI18n();
+
     const options = computed((): Option<TextOverflowStyle>[] => {
       return [
-        { label: this.$tc('label.text.overflow.truncate'), value: 'truncate' },
-        { label: this.$tc('label.text.overflow.fit'), value: 'fit' },
-        { label: this.$tc('label.text.overflow.expand'), value: 'expand' }
+        { label: i18n.value.tc('label.text.overflow.truncate'), value: 'truncate' },
+        { label: i18n.value.tc('label.text.overflow.fit'), value: 'fit' },
+        { label: i18n.value.tc('label.text.overflow.expand'), value: 'expand' }
       ];
     });
 

--- a/src/components/property/properties/StrokeColorProperty.vue
+++ b/src/components/property/properties/StrokeColorProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from '@/components/property/properties/base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'StrokeColorProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/StrokeTypeProperty.vue
+++ b/src/components/property/properties/StrokeTypeProperty.vue
@@ -10,6 +10,7 @@
 <script lang="ts">
 import { computed, defineComponent } from '@vue/composition-api';
 import SelectProperty, { Option } from '@/components/property/properties/base/SelectProperty.vue';
+import { useI18n } from '@/composables/useI18n';
 import { ItemBorderStyle } from '@/types';
 
 export default defineComponent({
@@ -23,11 +24,13 @@ export default defineComponent({
     }
   },
   setup (_, { emit }) {
+    const { i18n } = useI18n();
+
     const options = computed((): Option<ItemBorderStyle['borderStyle']>[] => {
       return [
-        { label: this.$tc('label.stroke.type.solid'), value: 'solid' },
-        { label: this.$tc('label.stroke.type.dashed'), value: 'dashed' },
-        { label: this.$tc('label.stroke.type.dotted'), value: 'dotted' }
+        { label: i18n.value.tc('label.stroke.type.solid'), value: 'solid' },
+        { label: i18n.value.tc('label.stroke.type.dashed'), value: 'dashed' },
+        { label: i18n.value.tc('label.stroke.type.dotted'), value: 'dotted' }
       ];
     });
 

--- a/src/components/property/properties/StrokeTypeProperty.vue
+++ b/src/components/property/properties/StrokeTypeProperty.vue
@@ -8,34 +8,37 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import SelectProperty, { Option } from '@/components/property/properties/base/SelectProperty.vue';
 import { ItemBorderStyle } from '@/types';
 
-export default Vue.extend({
-  name: 'StrokeTypeProperty',
+export default defineComponent({
   components: {
     SelectProperty
   },
   props: {
     value: {
-      type: String as PropType<ItemBorderStyle['borderStyle']>,
+      type: String as () => ItemBorderStyle['borderStyle'],
       required: true
     }
   },
-  computed: {
-    options (): Option<ItemBorderStyle['borderStyle']>[] {
+  setup (_, { emit }) {
+    const options = computed((): Option<ItemBorderStyle['borderStyle']>[] => {
       return [
         { label: this.$tc('label.stroke.type.solid'), value: 'solid' },
         { label: this.$tc('label.stroke.type.dashed'), value: 'dashed' },
         { label: this.$tc('label.stroke.type.dotted'), value: 'dotted' }
       ];
-    }
-  },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+    });
+
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      options,
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/StrokeWidthProperty.vue
+++ b/src/components/property/properties/StrokeWidthProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from '@/components/property/properties/base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'StrokeWidthProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/TextProperty.vue
+++ b/src/components/property/properties/TextProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextAreaProperty from './base/TextAreaProperty.vue';
 
-export default Vue.extend({
-  name: 'TextProperty',
+export default defineComponent({
   components: {
     TextAreaProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/TopProperty.vue
+++ b/src/components/property/properties/TopProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from '@/components/property/properties/base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'TopProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/VerticalAlignProperty.vue
+++ b/src/components/property/properties/VerticalAlignProperty.vue
@@ -8,34 +8,37 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import SelectProperty, { Option } from './base/SelectProperty.vue';
 import { VerticalAlign } from '@/types';
 
-export default Vue.extend({
-  name: 'VerticalAlignProperty',
+export default defineComponent({
   components: {
     SelectProperty
   },
   props: {
     value: {
-      type: String as PropType<VerticalAlign>,
+      type: String as () => VerticalAlign,
       required: true
     }
   },
-  computed: {
-    options (): Option<VerticalAlign>[] {
+  setup (_, { emit }) {
+    const options = computed((): Option<VerticalAlign>[] => {
       return [
         { label: this.$tc('label.align.vertical.top'), value: 'top' },
         { label: this.$tc('label.align.vertical.middle'), value: 'middle' },
         { label: this.$tc('label.align.vertical.bottom'), value: 'bottom' }
       ];
-    }
-  },
-  methods: {
-    update (value: VerticalAlign) {
-      this.$emit('change', value);
-    }
+    });
+
+    const update = (value: VerticalAlign) => {
+      emit('change', value);
+    };
+
+    return {
+      options,
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/VerticalAlignProperty.vue
+++ b/src/components/property/properties/VerticalAlignProperty.vue
@@ -10,6 +10,7 @@
 <script lang="ts">
 import { computed, defineComponent } from '@vue/composition-api';
 import SelectProperty, { Option } from './base/SelectProperty.vue';
+import { useI18n } from '@/composables/useI18n';
 import { VerticalAlign } from '@/types';
 
 export default defineComponent({
@@ -23,11 +24,13 @@ export default defineComponent({
     }
   },
   setup (_, { emit }) {
+    const { i18n } = useI18n();
+
     const options = computed((): Option<VerticalAlign>[] => {
       return [
-        { label: this.$tc('label.align.vertical.top'), value: 'top' },
-        { label: this.$tc('label.align.vertical.middle'), value: 'middle' },
-        { label: this.$tc('label.align.vertical.bottom'), value: 'bottom' }
+        { label: i18n.value.tc('label.align.vertical.top'), value: 'top' },
+        { label: i18n.value.tc('label.align.vertical.middle'), value: 'middle' },
+        { label: i18n.value.tc('label.align.vertical.bottom'), value: 'bottom' }
       ];
     });
 

--- a/src/components/property/properties/WidthProperty.vue
+++ b/src/components/property/properties/WidthProperty.vue
@@ -7,11 +7,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import TextProperty from '@/components/property/properties/base/TextProperty.vue';
 
-export default Vue.extend({
-  name: 'WidthProperty',
+export default defineComponent({
   components: {
     TextProperty
   },
@@ -21,10 +20,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    update (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const update = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/WordWrapProperty.vue
+++ b/src/components/property/properties/WordWrapProperty.vue
@@ -10,6 +10,7 @@
 <script lang="ts">
 import { computed, defineComponent } from '@vue/composition-api';
 import SelectProperty, { Option } from './base/SelectProperty.vue';
+import { useI18n } from '@/composables/useI18n';
 import { TextWordWrapStyle } from '@/types';
 
 export default defineComponent({
@@ -23,10 +24,12 @@ export default defineComponent({
     }
   },
   setup (_, { emit }) {
+    const { i18n } = useI18n();
+
     const options = computed((): Option<TextWordWrapStyle>[] => {
       return [
-        { label: this.$tc('label.text.word_wrap_none'), value: 'none' },
-        { label: this.$tc('label.text.word_wrap_break_word'), value: 'break-word' }
+        { label: i18n.value.tc('label.text.word_wrap_none'), value: 'none' },
+        { label: i18n.value.tc('label.text.word_wrap_break_word'), value: 'break-word' }
       ];
     });
 

--- a/src/components/property/properties/WordWrapProperty.vue
+++ b/src/components/property/properties/WordWrapProperty.vue
@@ -8,33 +8,36 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import SelectProperty, { Option } from './base/SelectProperty.vue';
 import { TextWordWrapStyle } from '@/types';
 
-export default Vue.extend({
-  name: 'WordWrapProperty',
+export default defineComponent({
   components: {
     SelectProperty
   },
   props: {
     value: {
-      type: String as PropType<TextWordWrapStyle>,
+      type: String as () => TextWordWrapStyle,
       required: true
     }
   },
-  computed: {
-    options (): Option<TextWordWrapStyle>[] {
+  setup (_, { emit }) {
+    const options = computed((): Option<TextWordWrapStyle>[] => {
       return [
         { label: this.$tc('label.text.word_wrap_none'), value: 'none' },
         { label: this.$tc('label.text.word_wrap_break_word'), value: 'break-word' }
       ];
-    }
-  },
-  methods: {
-    update (value: TextWordWrapStyle) {
-      this.$emit('change', value);
-    }
+    });
+
+    const update = (value: TextWordWrapStyle) => {
+      emit('change', value);
+    };
+
+    return {
+      options,
+      update
+    };
   }
 });
 </script>

--- a/src/components/property/properties/base/CheckProperty.vue
+++ b/src/components/property/properties/base/CheckProperty.vue
@@ -15,10 +15,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, toRefs } from '@vue/composition-api';
 
-export default Vue.extend({
-  name: 'CheckProperty',
+export default defineComponent({
   props: {
     label: {
       type: String,
@@ -29,10 +28,16 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    change () {
-      this.$emit('change', !this.value);
-    }
+  setup (props, { emit }) {
+    const { value } = toRefs(props);
+
+    const change = () => {
+      emit('change', !value.value);
+    };
+
+    return {
+      change
+    };
   }
 });
 </script>

--- a/src/components/property/properties/base/SelectProperty.vue
+++ b/src/components/property/properties/base/SelectProperty.vue
@@ -22,15 +22,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent } from '@vue/composition-api';
 
 export type Option<T> = {
   label: string;
   value: T;
 };
 
-export default Vue.extend({
-  name: 'SelectProperty',
+export default defineComponent({
   props: {
     label: {
       type: String,
@@ -41,14 +40,18 @@ export default Vue.extend({
       required: true
     },
     options: {
-      type: Array as PropType<Option<number | string>[]>,
+      type: Array as () => Option<number | string>[],
       required: true
     }
   },
-  methods: {
-    change (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const change = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      change
+    };
   }
 });
 </script>

--- a/src/components/property/properties/base/TextAreaProperty.vue
+++ b/src/components/property/properties/base/TextAreaProperty.vue
@@ -15,10 +15,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 
-export default Vue.extend({
-  name: 'TextAreaProperty',
+export default defineComponent({
   props: {
     label: {
       type: String,
@@ -29,10 +28,14 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
-    change (value: string) {
-      this.$emit('change', value);
-    }
+  setup (_, { emit }) {
+    const change = (value: string) => {
+      emit('change', value);
+    };
+
+    return {
+      change
+    };
   }
 });
 </script>

--- a/src/components/property/properties/base/TextProperty.vue
+++ b/src/components/property/properties/base/TextProperty.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, nextTick } from '@vue/composition-api';
+import { defineComponent, getCurrentInstance, nextTick } from '@vue/composition-api';
 
 export default defineComponent({
   props: {
@@ -34,13 +34,15 @@ export default defineComponent({
     }
   },
   setup (_, { emit }) {
+    const instance = getCurrentInstance();
+
     const change = async (value: string) => {
       emit('change', value);
 
       // When the value becomes the same as the current value due to rounding processing, etc.,
-      // the change cannot be detected, so the update is forcibly executed.
+      // the change cannot be detected, so the update is forcibly executedcak.
       await nextTick();
-      this.$forceUpdate();
+      instance?.proxy?.$forceUpdate();
     };
 
     return {

--- a/src/components/property/properties/base/TextProperty.vue
+++ b/src/components/property/properties/base/TextProperty.vue
@@ -16,10 +16,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, nextTick } from '@vue/composition-api';
 
-export default Vue.extend({
-  name: 'TextProperty',
+export default defineComponent({
   props: {
     label: {
       type: String,
@@ -34,15 +33,19 @@ export default Vue.extend({
       default: ''
     }
   },
-  methods: {
-    async change (value: string) {
-      this.$emit('change', value);
+  setup (_, { emit }) {
+    const change = async (value: string) => {
+      emit('change', value);
 
       // When the value becomes the same as the current value due to rounding processing, etc.,
       // the change cannot be detected, so the update is forcibly executed.
-      await this.$nextTick();
+      await nextTick();
       this.$forceUpdate();
-    }
+    };
+
+    return {
+      change
+    };
   }
 });
 </script>

--- a/src/components/toolbar/EditButtons.vue
+++ b/src/components/toolbar/EditButtons.vue
@@ -39,38 +39,36 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { history, editor, report } from '../../store';
 import { CopiedAnyItem } from '../../types';
 import MenuDropdownButton from './MenuDropdownButton.vue';
 import MenuDropdownSubTree from './MenuDropdownSubTree.vue';
 
-export default Vue.extend({
-  name: 'EditButtons',
+export default defineComponent({
   components: {
     MenuDropdownSubTree,
     MenuDropdownButton
   },
-  computed: {
-    undoable: () => history.getters.undoable(),
-    redoable: () => history.getters.redoable(),
-    activeEntityExists: () => report.getters.activeEntityExists()
-  },
-  methods: {
-    undo: () => history.actions.undo(),
-    redo: () => history.actions.redo(),
-    cut () {
+  setup () {
+    const undoable = computed(() => history.getters.undoable());
+    const redoable = computed(() => history.getters.redoable());
+    const activeEntityExists = computed(() => report.getters.activeEntityExists());
+
+    const undo = () => history.actions.undo();
+    const redo = () => history.actions.redo();
+    const cut = () => {
       const item = report.getters.activeItem();
       if (!item) return;
       editor.actions.setClipboard(report.getters.copiedItem(item.uid));
       report.actions.removeActiveItem();
-    },
-    copy () {
+    };
+    const copy = () => {
       const item = report.getters.activeItem();
       if (!item) return;
       editor.actions.setClipboard(report.getters.copiedItem(item.uid));
-    },
-    paste () {
+    };
+    const paste = () => {
       if (!editor.state.clipboard) return;
 
       const targetCanvas = report.getters.activeOrFirstCanvas();
@@ -78,10 +76,22 @@ export default Vue.extend({
       if (!targetCanvas) return;
 
       report.actions.pasteItem({ targetType: targetCanvas.type, targetUid: targetCanvas.uid, item: editor.state.clipboard as CopiedAnyItem });
-    },
-    remove () {
+    };
+    const remove = () => {
       report.actions.removeActiveEntity();
-    }
+    };
+
+    return {
+      undoable,
+      redoable,
+      activeEntityExists,
+      undo,
+      redo,
+      cut,
+      copy,
+      paste,
+      remove
+    };
   }
 });
 </script>

--- a/src/components/toolbar/FileButtons.vue
+++ b/src/components/toolbar/FileButtons.vue
@@ -38,30 +38,7 @@ export default defineComponent({
     const newReport = () => {
       location.reload();
     };
-    const save = async () => {
-      const schema = report.getters.toSchemaJSON();
 
-      if (!validateSchema(schema)) return;
-
-      const currentFilename = metadata.getters.filename();
-
-      if (currentFilename === null) {
-        const filename = await electronAPI.saveSchemaFileAs(schema);
-        if (filename) {
-          root.actions.saveSchema(filename);
-        }
-      } else {
-        await electronAPI.saveSchemaFile(schema, currentFilename);
-        root.actions.saveSchema();
-      }
-    };
-    const open = async () => {
-      const file = await electronAPI.openSchemaFile();
-
-      if (file) {
-        root.actions.loadSchema(file.schema, file.filename);
-      }
-    };
     const validateSchema = (jsonString: string): boolean => {
       const ajv = new Ajv({
         multipleOfPrecision: 3
@@ -83,6 +60,32 @@ export default defineComponent({
       }
 
       return true;
+    };
+
+    const save = async () => {
+      const schema = report.getters.toSchemaJSON();
+
+      if (!validateSchema(schema)) return;
+
+      const currentFilename = metadata.getters.filename();
+
+      if (currentFilename === null) {
+        const filename = await electronAPI.saveSchemaFileAs(schema);
+        if (filename) {
+          root.actions.saveSchema(filename);
+        }
+      } else {
+        await electronAPI.saveSchemaFile(schema, currentFilename);
+        root.actions.saveSchema();
+      }
+    };
+
+    const open = async () => {
+      const file = await electronAPI.openSchemaFile();
+
+      if (file) {
+        root.actions.loadSchema(file.schema, file.filename);
+      }
     };
 
     return {

--- a/src/components/toolbar/FileButtons.vue
+++ b/src/components/toolbar/FileButtons.vue
@@ -19,9 +19,9 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from '@vue/composition-api';
 import Ajv from 'ajv';
 import UIkit from 'uikit';
-import Vue from 'vue';
 import { report, root, metadata } from '../../store';
 import MenuDropdownButton from './MenuDropdownButton.vue';
 import MenuDropdownSubTree from './MenuDropdownSubTree.vue';
@@ -29,21 +29,19 @@ import layoutJsonSchema from '@/store/lib/layout-schema/schema.json';
 
 const { electronAPI } = window;
 
-export default Vue.extend({
-  name: 'FileButtons',
+export default defineComponent({
   components: {
     MenuDropdownSubTree,
     MenuDropdownButton
   },
-  methods: {
-    newReport () {
+  setup () {
+    const newReport = () => {
       location.reload();
-    },
-
-    async save () {
+    };
+    const save = async () => {
       const schema = report.getters.toSchemaJSON();
 
-      if (!this.validateSchema(schema)) return;
+      if (!validateSchema(schema)) return;
 
       const currentFilename = metadata.getters.filename();
 
@@ -56,17 +54,15 @@ export default Vue.extend({
         await electronAPI.saveSchemaFile(schema, currentFilename);
         root.actions.saveSchema();
       }
-    },
-
-    async open () {
+    };
+    const open = async () => {
       const file = await electronAPI.openSchemaFile();
 
       if (file) {
         root.actions.loadSchema(file.schema, file.filename);
       }
-    },
-
-    validateSchema (jsonString: string): boolean {
+    };
+    const validateSchema = (jsonString: string): boolean => {
       const ajv = new Ajv({
         multipleOfPrecision: 3
       });
@@ -87,7 +83,13 @@ export default Vue.extend({
       }
 
       return true;
-    }
+    };
+
+    return {
+      newReport,
+      save,
+      open
+    };
   }
 });
 </script>

--- a/src/components/toolbar/LocationButtons.vue
+++ b/src/components/toolbar/LocationButtons.vue
@@ -28,27 +28,33 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { report } from '../../store';
 import MenuDropdownButton from './MenuDropdownButton.vue';
 import MenuDropdownSubTree from './MenuDropdownSubTree.vue';
 
-export default Vue.extend({
-  name: 'LocationButtons',
+export default defineComponent({
   components: {
     MenuDropdownSubTree,
     MenuDropdownButton
   },
-  computed: {
-    isEditable (): boolean {
+  setup () {
+    const isEditable = computed((): boolean => {
       return !!report.getters.activeItem();
-    }
-  },
-  methods: {
-    bringToFront: () => report.actions.bringActiveItemToFront(),
-    bringForward: () => report.actions.bringActiveItemForward(),
-    sendToBack: () => report.actions.sendActiveItemToBack(),
-    sendBackward: () => report.actions.sendActiveItemBackward()
+    });
+
+    const bringToFront = () => report.actions.bringActiveItemToFront();
+    const bringForward = () => report.actions.bringActiveItemForward();
+    const sendToBack = () => report.actions.sendActiveItemToBack();
+    const sendBackward = () => report.actions.sendActiveItemBackward();
+
+    return {
+      isEditable,
+      bringToFront,
+      bringForward,
+      sendToBack,
+      sendBackward
+    };
   }
 });
 </script>

--- a/src/components/toolbar/MenuDropdown.vue
+++ b/src/components/toolbar/MenuDropdown.vue
@@ -65,7 +65,8 @@ export default defineComponent({
     };
 
     return {
-      handleMenuButtonClick
+      handleMenuButtonClick,
+      refDropdown
     };
   }
 });

--- a/src/components/toolbar/MenuDropdown.vue
+++ b/src/components/toolbar/MenuDropdown.vue
@@ -9,7 +9,7 @@
     </button>
 
     <div
-      ref="dropdown"
+      ref="refDropdown"
       uk-dropdown="mode: click"
       duration="0"
       delay-hide="0"
@@ -33,7 +33,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { defineComponent, ref } from '@vue/composition-api';
 import UIkit from 'uikit';
 import EditButtons from './EditButtons.vue';
 import FileButtons from './FileButtons.vue';
@@ -58,10 +58,12 @@ export default defineComponent({
     }
   },
   setup () {
+    const refDropdown = ref(null);
+
     const handleMenuButtonClick = (e: MouseEvent) => {
       if (!e.target || !(e.target as HTMLElement).closest('.th-menu-button')) return;
 
-      UIkit.dropdown(this.$refs.dropdown).hide();
+      UIkit.dropdown(refDropdown.value).hide();
     };
 
     return {

--- a/src/components/toolbar/MenuDropdown.vue
+++ b/src/components/toolbar/MenuDropdown.vue
@@ -33,8 +33,8 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from '@vue/composition-api';
 import UIkit from 'uikit';
-import Vue from 'vue';
 import EditButtons from './EditButtons.vue';
 import FileButtons from './FileButtons.vue';
 import LocationButtons from './LocationButtons.vue';
@@ -42,8 +42,7 @@ import SectionButtons from './SectionButtons.vue';
 import StackViewButtons from './StackViewButtons.vue';
 import ZoomButtons from './ZoomButtons.vue';
 
-export default Vue.extend({
-  name: 'MenuDropdown',
+export default defineComponent({
   components: {
     FileButtons,
     EditButtons,
@@ -58,12 +57,16 @@ export default Vue.extend({
       default: false
     }
   },
-  methods: {
-    handleMenuButtonClick (e: MouseEvent) {
+  setup () {
+    const handleMenuButtonClick = (e: MouseEvent) => {
       if (!e.target || !(e.target as HTMLElement).closest('.th-menu-button')) return;
 
       UIkit.dropdown(this.$refs.dropdown).hide();
-    }
+    };
+
+    return {
+      handleMenuButtonClick
+    };
   }
 });
 </script>

--- a/src/components/toolbar/MenuDropdownButton.vue
+++ b/src/components/toolbar/MenuDropdownButton.vue
@@ -12,10 +12,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 
-export default Vue.extend({
-  name: 'MenuDropdownButton',
+export default defineComponent({
   props: {
     text: {
       type: String,
@@ -30,10 +29,14 @@ export default Vue.extend({
       default: false
     }
   },
-  methods: {
-    click () {
-      this.$emit('click');
-    }
+  setup (_, { emit }) {
+    const click = () => {
+      emit('click');
+    };
+
+    return {
+      click
+    };
   }
 });
 </script>

--- a/src/components/toolbar/MenuDropdownSubTree.vue
+++ b/src/components/toolbar/MenuDropdownSubTree.vue
@@ -11,10 +11,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 
-export default Vue.extend({
-  name: 'MenuDropdownSubTree',
+export default defineComponent({
   props: {
     title: {
       type: String,

--- a/src/components/toolbar/SectionButtons.vue
+++ b/src/components/toolbar/SectionButtons.vue
@@ -27,19 +27,18 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { report } from '../../store';
 import MenuDropdownButton from './MenuDropdownButton.vue';
 import MenuDropdownSubTree from './MenuDropdownSubTree.vue';
 
-export default Vue.extend({
-  name: 'SectionTools',
+export default defineComponent({
   components: {
     MenuDropdownSubTree,
     MenuDropdownButton
   },
-  computed: {
-    activeSectionExists () {
+  setup () {
+    const activeSectionExists = computed(() => {
       if (!report.state.activeEntity || report.state.activeEntity.type !== 'section') return false;
 
       const uid = report.state.activeEntity.uid;
@@ -47,14 +46,22 @@ export default Vue.extend({
       return report.state.sections.headers.includes(uid) ||
         report.state.sections.details.includes(uid) ||
         report.state.sections.footers.includes(uid);
-    }
-  },
-  methods: {
-    addNewHeader: () => report.actions.addNewHeader(),
-    addNewDetail: () => report.actions.addNewDetail(),
-    addNewFooter: () => report.actions.addNewFooter(),
-    moveUp: () => report.actions.moveUpActiveSection(),
-    moveDown: () => report.actions.moveDownActiveSection()
+    });
+
+    const addNewHeader = () => report.actions.addNewHeader();
+    const addNewDetail = () => report.actions.addNewDetail();
+    const addNewFooter = () => report.actions.addNewFooter();
+    const moveUp = () => report.actions.moveUpActiveSection();
+    const moveDown = () => report.actions.moveDownActiveSection();
+
+    return {
+      activeSectionExists,
+      addNewHeader,
+      addNewDetail,
+      addNewFooter,
+      moveUp,
+      moveDown
+    };
   }
 });
 </script>

--- a/src/components/toolbar/StackViewButtons.vue
+++ b/src/components/toolbar/StackViewButtons.vue
@@ -19,26 +19,31 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { report } from '../../store';
 import MenuDropdownButton from './MenuDropdownButton.vue';
 import MenuDropdownSubTree from './MenuDropdownSubTree.vue';
 
-export default Vue.extend({
-  name: 'StackViewButtons',
+export default defineComponent({
   components: {
     MenuDropdownSubTree,
     MenuDropdownButton
   },
-  computed: {
-    isEditable (): boolean {
+  setup () {
+    const isEditable = computed((): boolean => {
       return !!report.getters.activeStackView();
-    }
-  },
-  methods: {
-    addRow: () => report.actions.addNewRowToActiveStackView(),
-    moveRowUp: () => report.actions.moveUpActiveStackViewRow(),
-    moveRowDown: () => report.actions.moveDownActiveStackViewRow()
+    });
+
+    const addRow = () => report.actions.addNewRowToActiveStackView();
+    const moveRowUp = () => report.actions.moveUpActiveStackViewRow();
+    const moveRowDown = () => report.actions.moveDownActiveStackViewRow();
+
+    return {
+      isEditable,
+      addRow,
+      moveRowUp,
+      moveRowDown
+    };
   }
 });
 </script>

--- a/src/components/toolbar/ToolButton.vue
+++ b/src/components/toolbar/ToolButton.vue
@@ -10,10 +10,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 
-export default Vue.extend({
-  name: 'ToolButton',
+export default defineComponent({
   props: {
     active: {
       type: Boolean,
@@ -24,10 +23,14 @@ export default Vue.extend({
       default: ''
     }
   },
-  methods: {
-    click () {
-      this.$emit('click');
-    }
+  setup (_, { emit }) {
+    const click = () => {
+      emit('click');
+    };
+
+    return {
+      click
+    };
   }
 });
 </script>

--- a/src/components/toolbar/ToolSelect.vue
+++ b/src/components/toolbar/ToolSelect.vue
@@ -78,7 +78,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@vue/composition-api';
 import { selectImage } from '../../lib/select-image';
 import { editor, report } from '../../store';
 import ItemIcon from '../icons/ItemIcon.vue';
@@ -87,27 +87,25 @@ import MenuDropdown from './MenuDropdown.vue';
 import ToolButton from './ToolButton.vue';
 import { ToolType } from '@/types';
 
-export default Vue.extend({
-  name: 'ToolSelect',
+export default defineComponent({
   components: {
     MenuDropdown,
     ToolButton,
     ItemIcon,
     LocaleMenu
   },
-  computed: {
-    activeTool () {
+  setup () {
+    const activeTool = computed(() => {
       return editor.state.activeTool;
-    }
-  },
-  methods: {
-    activateTool (tool: ToolType) {
+    });
+
+    const activateTool = (tool: ToolType) => {
       editor.actions.activateTool({ tool });
-    },
-    isActiveTool (tool: ToolType) {
-      return this.activeTool === tool;
-    },
-    async selectImage () {
+    };
+    const isActiveTool = (tool: ToolType) => {
+      return activeTool.value === tool;
+    };
+    const selectImage = async () => {
       const targetCanvas = report.getters.activeOrFirstCanvas();
 
       if (!targetCanvas) return;
@@ -128,7 +126,13 @@ export default Vue.extend({
           base64: imageData.base64
         }
       });
-    }
+    };
+
+    return {
+      activateTool,
+      isActiveTool,
+      selectImage
+    };
   }
 });
 </script>

--- a/src/components/toolbar/ToolSelect.vue
+++ b/src/components/toolbar/ToolSelect.vue
@@ -52,7 +52,7 @@
 
     <ToolButton
       description="Image"
-      @click="selectImage"
+      @click="openSelectImage"
     >
       <ItemIcon type="image" />
     </ToolButton>
@@ -105,7 +105,7 @@ export default defineComponent({
     const isActiveTool = (tool: ToolType) => {
       return activeTool.value === tool;
     };
-    const selectImage = async () => {
+    const openSelectImage = async () => {
       const targetCanvas = report.getters.activeOrFirstCanvas();
 
       if (!targetCanvas) return;
@@ -131,7 +131,7 @@ export default defineComponent({
     return {
       activateTool,
       isActiveTool,
-      selectImage
+      openSelectImage
     };
   }
 });

--- a/src/components/toolbar/ZoomButtons.vue
+++ b/src/components/toolbar/ZoomButtons.vue
@@ -28,22 +28,28 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import { editor } from '../../store';
 import MenuDropdownButton from './MenuDropdownButton.vue';
 import MenuDropdownSubTree from './MenuDropdownSubTree.vue';
 
-export default Vue.extend({
-  name: 'EditButtons',
+export default defineComponent({
   components: {
     MenuDropdownSubTree,
     MenuDropdownButton
   },
-  methods: {
-    setZoomRate: (rate: number) => editor.actions.setZoomRate(rate),
-    resetZoom: () => editor.actions.resetZoom(),
-    zoomIn: () => editor.actions.zoomIn(),
-    zoomOut: () => editor.actions.zoomOut()
+  setup () {
+    const setZoomRate = (rate: number) => editor.actions.setZoomRate(rate);
+    const resetZoom = () => editor.actions.resetZoom();
+    const zoomIn = () => editor.actions.zoomIn();
+    const zoomOut = () => editor.actions.zoomOut();
+
+    return {
+      setZoomRate,
+      resetZoom,
+      zoomIn,
+      zoomOut
+    };
   }
 });
 </script>

--- a/src/components/tree-view/GraphicItemNode.vue
+++ b/src/components/tree-view/GraphicItemNode.vue
@@ -12,24 +12,23 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent } from '@vue/composition-api';
 import { Item } from '../../types';
 import ItemIcon from '../icons/ItemIcon.vue';
 import NodeButton from './NodeButton.vue';
 
-export default Vue.extend({
-  name: 'GraphicItemNode',
+export default defineComponent({
   components: {
     ItemIcon,
     NodeButton
   },
   props: {
     itemId: {
-      type: String as PropType<Item['id']>,
+      type: String as () => Item['id'],
       required: true
     },
     itemType: {
-      type: String as PropType<Item['type']>,
+      type: String as () => Item['type'],
       required: true
     },
     active: {
@@ -37,10 +36,14 @@ export default Vue.extend({
       default: false
     }
   },
-  methods: {
-    emitActivate () {
-      this.$emit('activate');
-    }
+  setup (_, { emit }) {
+    const emitActivate = () => {
+      emit('activate');
+    };
+
+    return {
+      emitActivate
+    };
   }
 });
 </script>

--- a/src/components/tree-view/NodeButton.vue
+++ b/src/components/tree-view/NodeButton.vue
@@ -10,10 +10,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 
-export default Vue.extend({
-  name: 'NodeButton',
+export default defineComponent({
   props: {
     name: {
       type: String,
@@ -28,15 +27,21 @@ export default Vue.extend({
       default: false
     }
   },
-  computed: {
-    label () {
-      return this.id !== '' ? `#${this.id}` : this.name;
-    }
-  },
-  methods: {
-    emitClick () {
-      this.$emit('click');
-    }
+  setup (props, { emit }) {
+    const { name, id } = toRefs(props);
+
+    const label = computed(() => {
+      return id.value !== '' ? `#${id.value}` : name.value;
+    });
+
+    const emitClick = () => {
+      emit('click');
+    };
+
+    return {
+      label,
+      emitClick
+    };
   }
 });
 </script>

--- a/src/components/tree-view/SectionNode.vue
+++ b/src/components/tree-view/SectionNode.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { report } from '../../store';
 import { AnyItem, Section, ItemUid } from '../../types';
 import SectionIcon from '../icons/SectionIcon.vue';
@@ -43,8 +43,7 @@ import GraphicItemNode from './GraphicItemNode.vue';
 import NodeButton from './NodeButton.vue';
 import StackViewItemNode from './StackViewItemNode.vue';
 
-export default Vue.extend({
-  name: 'SectionNode',
+export default defineComponent({
   components: {
     GraphicItemNode,
     StackViewItemNode,
@@ -53,15 +52,15 @@ export default Vue.extend({
   },
   props: {
     itemUids: {
-      type: Array as PropType<ItemUid[]>,
+      type: Array as () => ItemUid[],
       required: true
     },
     sectionId: {
-      type: String as PropType<Section['id']>,
+      type: String as () => Section['id'],
       required: true
     },
     sectionType: {
-      type: String as PropType<Section['type']>,
+      type: String as () => Section['type'],
       required: true
     },
     active: {
@@ -69,19 +68,27 @@ export default Vue.extend({
       default: false
     }
   },
-  computed: {
-    items (): AnyItem[] {
-      return this.itemUids.map(uid => report.getters.findItem(uid));
-    },
-    activeItemUid: () => report.getters.activeItem()?.uid
-  },
-  methods: {
-    emitActivate () {
-      this.$emit('activate');
-    },
-    activateItem (uid: ItemUid) {
+  setup (props, { emit }) {
+    const { itemUids } = toRefs(props);
+
+    const items = computed((): AnyItem[] => {
+      return itemUids.value.map(uid => report.getters.findItem(uid));
+    });
+    const activeItemUid = computed(() => report.getters.activeItem()?.uid);
+
+    const emitActivate = () => {
+      emit('activate');
+    };
+    const activateItem = (uid: ItemUid) => {
       report.actions.activateEntity({ type: 'item', uid });
-    }
+    };
+
+    return {
+      items,
+      activeItemUid,
+      emitActivate,
+      activateItem
+    };
   }
 });
 </script>

--- a/src/components/tree-view/StackViewItemNode.vue
+++ b/src/components/tree-view/StackViewItemNode.vue
@@ -20,15 +20,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { report } from '../../store';
 import { StackViewItem, StackViewRow, StackViewRowUid } from '../../types';
 import ItemIcon from '../icons/ItemIcon.vue';
 import NodeButton from './NodeButton.vue';
 import StackViewItemRowNode from './StackViewItemRowNode.vue';
 
-export default Vue.extend({
-  name: 'StackViewItemNode',
+export default defineComponent({
   components: {
     StackViewItemRowNode,
     NodeButton,
@@ -36,11 +35,11 @@ export default Vue.extend({
   },
   props: {
     itemId: {
-      type: String as PropType<StackViewItem['id']>,
+      type: String as () => StackViewItem['id'],
       required: true
     },
     rowUids: {
-      type: Array as PropType<StackViewRowUid[]>,
+      type: Array as () => StackViewRowUid[],
       required: true
     },
     active: {
@@ -48,19 +47,27 @@ export default Vue.extend({
       default: false
     }
   },
-  computed: {
-    rows (): StackViewRow[] {
-      return this.rowUids.map(uid => report.getters.findStackViewRow(uid));
-    },
-    activeRowUid: () => report.getters.activeStackViewRow()?.uid
-  },
-  methods: {
-    emitActivate () {
-      this.$emit('activate');
-    },
-    activateRow (uid: StackViewRowUid) {
+  setup (props, { emit }) {
+    const { rowUids } = toRefs(props);
+
+    const rows = computed((): StackViewRow[] => {
+      return rowUids.value.map(uid => report.getters.findStackViewRow(uid));
+    });
+    const activeRowUid = computed(() => report.getters.activeStackViewRow()?.uid);
+
+    const emitActivate = () => {
+      emit('activate');
+    };
+    const activateRow = (uid: StackViewRowUid) => {
       report.actions.activateEntity({ type: 'stack-view-row', uid });
-    }
+    };
+
+    return {
+      rows,
+      activeRowUid,
+      emitActivate,
+      activateRow
+    };
   }
 });
 </script>

--- a/src/components/tree-view/StackViewItemRowNode.vue
+++ b/src/components/tree-view/StackViewItemRowNode.vue
@@ -24,25 +24,24 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { computed, defineComponent, toRefs } from '@vue/composition-api';
 import { report } from '../../store';
 import { ItemUid, StackViewRow, GraphicItem } from '../../types';
 import GraphicItemNode from './GraphicItemNode.vue';
 import NodeButton from './NodeButton.vue';
 
-export default Vue.extend({
-  name: 'StackViewItemRowNode',
+export default defineComponent({
   components: {
     GraphicItemNode,
     NodeButton
   },
   props: {
     rowId: {
-      type: String as PropType<StackViewRow['id']>,
+      type: String as () => StackViewRow['id'],
       required: true
     },
     itemUids: {
-      type: Array as PropType<ItemUid[]>,
+      type: Array as () => ItemUid[],
       required: true
     },
     active: {
@@ -50,19 +49,27 @@ export default Vue.extend({
       default: false
     }
   },
-  computed: {
-    items (): GraphicItem[] {
-      return this.itemUids.map(uid => report.getters.findGraphicItem(uid));
-    },
-    activeItemUid: () => report.getters.activeItem()?.uid
-  },
-  methods: {
-    emitActivate () {
-      this.$emit('activate');
-    },
-    activateItem (uid: ItemUid) {
+  setup (props, { emit }) {
+    const { itemUids } = toRefs(props);
+
+    const items = computed((): GraphicItem[] => {
+      return itemUids.value.map(uid => report.getters.findGraphicItem(uid));
+    });
+    const activeItemUid = computed(() => report.getters.activeItem()?.uid);
+
+    const emitActivate = () => {
+      emit('activate');
+    };
+    const activateItem = (uid: ItemUid) => {
       report.actions.activateEntity({ type: 'item', uid });
-    }
+    };
+
+    return {
+      items,
+      activeItemUid,
+      emitActivate,
+      activateItem
+    };
   }
 });
 </script>

--- a/src/composables/useI18n.ts
+++ b/src/composables/useI18n.ts
@@ -1,0 +1,15 @@
+import { computed, getCurrentInstance } from '@vue/composition-api';
+
+export const useI18n = () => {
+  const instance = getCurrentInstance()?.proxy;
+
+  if (!instance) {
+    throw new Error('Cannot useI18n outside of component');
+  }
+
+  const i18n = computed(() => instance.$i18n);
+
+  return {
+    i18n
+  };
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import VueCompotisionAPI from '@vue/composition-api';
 import Vue from 'vue';
 import App from './App.vue';
 import i18n from './i18n';
@@ -7,6 +8,7 @@ import 'uikit/dist/css/uikit.min.css';
 import 'uikit/dist/js/uikit.min.js';
 
 Vue.config.productionTip = false;
+Vue.use(VueCompotisionAPI);
 
 new Vue({
   i18n,


### PR DESCRIPTION
This PR fixes a part of #18 

手動でやるのが無理すぎたので、変換スクリプトで一括移行した。9割程度移行できていると思う。スクリプトは gist においてある。
https://gist.github.com/hidakatsuya/f1faf5753b6eddf9cf4bc4dae276f181

## Steps

- [x] Bulk convert to Composition API by script
- [x] Fix lint, migrate unsupported, etc
  - [x] lint warnings
  - [x] src/components/ReportCanvas.vue
  - [x] src/components/ReportPane.vue
  - [x] src/components/SectionCanvas.vue
  - [x] src/components/toolbar/MenuDropdown.vue
  - [x] src/components/toolbar/ToolSelect.vue
  - [x] src/components/property/properties/base/TextProperty.vue
  - [x] src/components/property/properties/HorizontalAlignProperty.vue
  - [x] src/components/property/properties/OverflowProperty.vue
  - [x] src/components/property/properties/StrokeTypeProperty.vue
  - [x] src/components/property/properties/VerticalAlignProperty.vue
  - [x] src/components/property/properties/WordWrapProperty.vue
  - [x] src/components/items/TextItemBody.vue
