### PR TITLE
Fix icon images are not displayed in the production package

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -5,7 +5,6 @@ import os from 'os';
 import path from 'path';
 import { app, protocol, BrowserWindow, Menu, ipcMain, dialog } from 'electron';
 import installExtension, { VUEJS3_DEVTOOLS } from 'electron-devtools-installer';
-import { createProtocol } from 'vue-cli-plugin-electron-builder/lib';
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
 // Scheme must be registered before the app is ready
@@ -65,9 +64,9 @@ async function createWindow () {
     await win.loadURL(process.env.WEBPACK_DEV_SERVER_URL);
     if (!process.env.IS_TEST) win.webContents.openDevTools();
   } else {
-    createProtocol('app');
     // Load the index.html when not in development
-    win.loadURL('app://./index.html');
+    // eslint-disable-next-line n/no-path-concat
+    win.loadURL(`file://${__dirname}/index.html`);
   }
 
   if (!isDevelopment) {

--- a/vue.config.js
+++ b/vue.config.js
@@ -22,6 +22,9 @@ module.exports = defineConfig({
           icon: 'build/icon.ico'
         }
       },
+      // This setting is for a workaround for the problem that assets like font file are not being loaded.
+      // https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/1647
+      customFileProtocol: './',
       preload: 'src/preload.ts'
     },
     i18n: {


### PR DESCRIPTION
This PR fixes https://github.com/thinreports/thinreports-section-editor/issues/43. I refer to https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/1647 and [doc: Changing the File Loading Protocol](https://nklayman.github.io/vue-cli-plugin-electron-builder/guide/configuration.html#changing-the-file-loading-protocol) for the solution.


I have confirmed that the icon images are displayed with the built package in my environment (Ubuntu 22.04):
![image](https://user-images.githubusercontent.com/739339/167286678-0e98d053-946c-43a3-95ce-94fcc8d5d0cf.png)
